### PR TITLE
Add licensing metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,188 @@
+Codemagic Server License
+(Based on Functional Source License, Version 1.1)
+
+Abbreviation
+
+Codemagic-FSL-1.1-Apache-2.0
+
+Notice
+
+Copyright (C) 2026 Nevercode Ltd
+
+TERMS AND CONDITIONS
+
+1. Definitions
+
+"Licensor"
+
+Nevercode Ltd, a company incorporated under the laws of England and Wales in
+the UK, Company number 10577696, with its registered address at Lytchett House,
+Wareham Road, Poole, Dorset, England, BH16 6FA, UK.
+
+"You" or "your"
+
+The individual or legal entity exercising rights under this License.
+
+"Licensed Work"
+
+Codemagic Patch, including all source code, documentation, and associated files
+made available by Licensor under this License. The software is Copyright (C) 2026
+Nevercode Ltd.
+
+"Change License"
+
+Apache License, Version 2.0
+
+"Change Date"
+
+Two (2) years from the date the Licensed Work is made available under this
+License. Each separately published version of the Licensed Work has its own
+Change Date. On the Change Date, or if Licensor publicly posts a later Change
+Date for a given version, the later of the two dates, the Licensed Work will
+become available under the Change License.
+
+2. License Grant
+
+Subject to the Terms and Conditions of this License, Licensor hereby grants you
+a non-exclusive, worldwide, royalty-free license to use, copy, modify, create
+derivative works, and redistribute the Licensed Work, subject to the Use
+Limitation and the Competing Use restriction set out below.
+
+All rights in the Licensed Work not expressly granted herein are reserved by
+Licensor.
+
+3. Use Limitation
+
+3.1. Free Use
+
+The Licensed Work may be used free of charge, provided that the total number of
+unique devices that request an update from the Licensed Work in any calendar
+month ("Monthly Active Users") does not exceed one million (1,000,000).
+
+3.2. Commercial Use
+
+If Monthly Active Users exceeds this threshold in any calendar month, you must,
+before continuing such use in the following calendar month, either obtain a
+separate commercial license from Licensor or cease all use of the Licensed Work.
+
+3.3. Measurement of Use
+
+Monthly Active Users is measured by counting each unique device identifier that
+initiates at least one update request to the Licensed Work during a given
+calendar month. A device that requests multiple updates within the same calendar
+month is counted only once.
+
+4. Use Restrictions
+
+4.1. Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. Permitted
+Purposes specifically include using the Licensed Work: (a) for your own internal
+use and access; (b) for non-commercial education; (c) for non-commercial
+research; and (d) in connection with professional services that you provide to a
+licensee using the Licensed Work in accordance with these Terms and Conditions.
+
+4.2. Competing Use
+
+A Competing Use means making the Licensed Work available to others in a
+commercial product or service that:
+
+(a) substitutes for the Licensed Work;
+
+(b) substitutes for any other product or service offered by Licensor using the
+    Licensed Work that exists as of the date the Licensed Work is made available
+    under this License; or
+
+(c) offers the same or substantially similar functionality as the Licensed Work.
+
+5. Redistribution Requirements
+
+Redistribution in source or binary form, with or without modification, is
+permitted provided that the following conditions are met:
+
+(a) You must give any recipients of the Licensed Work a copy of this License.
+
+(b) You must cause any modified files to carry prominent notices stating that
+    you changed the files.
+
+(c) You must retain, in the source form of any derivative works, all copyright,
+    patent, trademark, and attribution notices from the source form of the
+    Licensed Work, excluding those notices that do not pertain to any part of
+    the derivative works.
+
+(d) You may not remove or alter any license notices, including copyright
+    notices, patent notices, disclaimers of warranty, or limitations of
+    liability, contained within the source form of the Licensed Work.
+
+6. Covenants
+
+Each contributor to the Licensed Work covenants that they have the right to
+grant the license set out in this License.
+
+7. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Licensed Work.
+
+8. Disclaimer of Warranty
+
+To the maximum extent permitted by applicable law, the Licensed Work is provided
+"as is" and "as available", without warranties or conditions of any kind,
+whether express, implied or statutory.
+
+To the maximum extent permitted by applicable law, Licensor disclaims all
+warranties and conditions, including any implied warranties or conditions of
+merchantability, fitness for a particular purpose, title, non-infringement,
+accuracy, availability, security or reliability.
+
+9. Limitation of Liability
+
+To the maximum extent permitted by applicable law, Licensor will not be liable
+for any direct, indirect, incidental, special, consequential, exemplary or
+punitive damages, or for any loss of profits, revenue, goodwill, data, business
+opportunities or anticipated savings, arising out of or in connection with the
+Licensed Work or this License.
+
+10. Termination
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work. Upon termination, you must immediately cease all use and
+distribution of the Licensed Work, destroy all copies of the Licensed Work in
+your possession or control, and upon Licensor's request, certify such
+destruction in writing. Termination does not affect any rights or obligations
+that by their nature are intended to survive termination, including sections
+titled "Disclaimer of Warranty," "Limitation of Liability," "Indemnification,"
+and "Termination".
+
+11. Indemnification
+
+You shall indemnify, defend, and hold harmless Licensor and its officers,
+directors, employees, and agents from and against any claims, damages, losses,
+liabilities, costs, and expenses (including reasonable legal fees) arising out of
+or in connection with your use of the Licensed Work or any breach of this
+License.
+
+12. Transition to Change License
+
+On the Change Date, the Terms and Conditions of this License, including the Use
+Limitation and the Competing Use restriction, shall cease to apply to the
+applicable version of the Licensed Work, and such version shall thereafter be
+available under the Change License. Each version of the Licensed Work has its own
+Change Date, calculated from the date that specific version was first made
+available by Licensor.
+
+13. Separate Mobile SDK License
+
+The Codemagic Mobile SDK is not covered by this License. The Mobile SDK is made
+available under the Apache License, Version 2.0, as separately documented in the
+Mobile SDK repository. The Mobile SDK may not be used to circumvent or avoid the
+restrictions of this License as applied to the Licensed Work.
+
+14. Governing Law and Jurisdiction
+
+This License shall be governed by and construed in accordance with the laws of
+the Republic of Estonia, without regard to its conflict of laws principles. Any
+disputes arising out of or in connection with this License shall be submitted to
+the exclusive jurisdiction of the courts of the Republic of Estonia.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,66 @@
+# Licensing
+
+Codemagic Patch is distributed under **two licenses**, split by component. The
+client-facing pieces (the React Native SDK and the CLI) are permissively
+licensed under **Apache License 2.0**, while the server and its supporting
+components are licensed under the **Codemagic Server License** (a
+[Functional Source License 1.1](https://fsl.software/) variant that converts to
+Apache 2.0).
+
+This file is a human-readable summary. The authoritative terms are the `LICENSE`
+file in the repository root and the per-directory `LICENSE` files listed below.
+
+## What is licensed how
+
+| Path | Component | License |
+| --- | --- | --- |
+| `client/` | React Native client SDK (the "Mobile SDK") | Apache-2.0 |
+| `cli/` | `codemagic-patch` / `cmpatch` CLI | Apache-2.0 |
+| `shared/` | Shared protocol types and schemas (bundled into the CLI) | Apache-2.0 |
+| `examples/` | Integration example apps | Apache-2.0 |
+| `benchmarks/` | Benchmark app | Apache-2.0 |
+| `server/` | Update-delivery server | Codemagic Server License |
+| `web-dashboard/` | Management dashboard | Codemagic Server License |
+| `infra/` | Deployment infrastructure (Pulumi) | Codemagic Server License |
+| `deploy/` | Deployment configuration | Codemagic Server License |
+| *(repository root and everything else)* | — | Codemagic Server License |
+
+The root `LICENSE` (Codemagic Server License) is the default for the repository.
+A directory that carries its own `LICENSE` file is governed by that file
+instead.
+
+`shared/` is Apache-2.0 because its source is compiled into the published,
+Apache-licensed CLI bundle. The Codemagic Server License explicitly permits
+including Apache-2.0 code (§5), so the FSL-licensed server can depend on it
+freely.
+
+## Codemagic Server License — key terms (summary, not legal text)
+
+- **Free use** up to **1,000,000 Monthly Active Users** (unique devices that
+  request an update in a calendar month). Above that threshold you need a
+  separate commercial license.
+- **No Competing Use**: you may not offer the software as a commercial product
+  or service that substitutes for, or provides substantially similar
+  functionality to, Codemagic Patch.
+- **Permitted purposes** include internal use, non-commercial education and
+  research, and professional services for a licensee.
+- **Converts to Apache 2.0** two (2) years after each version is published (the
+  "Change Date").
+- Per §13, the Mobile SDK (the `client/` package) is **not** covered by the
+  Server License and is provided under Apache-2.0.
+
+For a commercial license above the Monthly Active Users threshold, contact
+Codemagic (Nevercode Ltd) — <https://codemagic.io>.
+
+## License identifiers
+
+In `package.json`:
+
+- Apache components: `"license": "Apache-2.0"` (a listed SPDX identifier).
+- Server components: `"license": "SEE LICENSE IN LICENSE"`. This is npm's required
+  form for licenses that are not on the SPDX License List; npm's validator rejects
+  a `LicenseRef-...` value in this field. All server packages are `private` and are
+  not published.
+
+For SBOM / SPDX / REUSE tooling (not `package.json`), the server license is
+referenced as `LicenseRef-Codemagic-FSL-1.1-Apache-2.0`.

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nevercode Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,6 +2,7 @@
   "name": "codemagic-patch",
   "version": "0.1.0",
   "description": "Codemagic Patch CLI for releasing and managing over-the-air React Native updates",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/codemagic-ci-cd/codemagic-patch.git",

--- a/client/CodemagicPatchClient.podspec
+++ b/client/CodemagicPatchClient.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.version      = package["version"] || "0.0.0"
   s.summary      = "React Native Codemagic Patch client"
   s.homepage     = "https://github.com/codemagic-ci-cd/codemagic-patch"
-  s.license      = { :type => "MIT" }
+  s.license      = { :type => "Apache-2.0" }
   s.authors      = { "Codemagic" => "codemagic-patch@example.invalid" }
   s.platforms    = { :ios => "13.4" }
   s.source       = { :path => "." }

--- a/client/LICENSE
+++ b/client/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nevercode Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@codemagic/patch-client",
   "version": "0.0.0",
+  "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "react-native": "./src/index.ts",

--- a/deploy/LICENSE
+++ b/deploy/LICENSE
@@ -1,0 +1,188 @@
+Codemagic Server License
+(Based on Functional Source License, Version 1.1)
+
+Abbreviation
+
+Codemagic-FSL-1.1-Apache-2.0
+
+Notice
+
+Copyright (C) 2026 Nevercode Ltd
+
+TERMS AND CONDITIONS
+
+1. Definitions
+
+"Licensor"
+
+Nevercode Ltd, a company incorporated under the laws of England and Wales in
+the UK, Company number 10577696, with its registered address at Lytchett House,
+Wareham Road, Poole, Dorset, England, BH16 6FA, UK.
+
+"You" or "your"
+
+The individual or legal entity exercising rights under this License.
+
+"Licensed Work"
+
+Codemagic Patch, including all source code, documentation, and associated files
+made available by Licensor under this License. The software is Copyright (C) 2026
+Nevercode Ltd.
+
+"Change License"
+
+Apache License, Version 2.0
+
+"Change Date"
+
+Two (2) years from the date the Licensed Work is made available under this
+License. Each separately published version of the Licensed Work has its own
+Change Date. On the Change Date, or if Licensor publicly posts a later Change
+Date for a given version, the later of the two dates, the Licensed Work will
+become available under the Change License.
+
+2. License Grant
+
+Subject to the Terms and Conditions of this License, Licensor hereby grants you
+a non-exclusive, worldwide, royalty-free license to use, copy, modify, create
+derivative works, and redistribute the Licensed Work, subject to the Use
+Limitation and the Competing Use restriction set out below.
+
+All rights in the Licensed Work not expressly granted herein are reserved by
+Licensor.
+
+3. Use Limitation
+
+3.1. Free Use
+
+The Licensed Work may be used free of charge, provided that the total number of
+unique devices that request an update from the Licensed Work in any calendar
+month ("Monthly Active Users") does not exceed one million (1,000,000).
+
+3.2. Commercial Use
+
+If Monthly Active Users exceeds this threshold in any calendar month, you must,
+before continuing such use in the following calendar month, either obtain a
+separate commercial license from Licensor or cease all use of the Licensed Work.
+
+3.3. Measurement of Use
+
+Monthly Active Users is measured by counting each unique device identifier that
+initiates at least one update request to the Licensed Work during a given
+calendar month. A device that requests multiple updates within the same calendar
+month is counted only once.
+
+4. Use Restrictions
+
+4.1. Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. Permitted
+Purposes specifically include using the Licensed Work: (a) for your own internal
+use and access; (b) for non-commercial education; (c) for non-commercial
+research; and (d) in connection with professional services that you provide to a
+licensee using the Licensed Work in accordance with these Terms and Conditions.
+
+4.2. Competing Use
+
+A Competing Use means making the Licensed Work available to others in a
+commercial product or service that:
+
+(a) substitutes for the Licensed Work;
+
+(b) substitutes for any other product or service offered by Licensor using the
+    Licensed Work that exists as of the date the Licensed Work is made available
+    under this License; or
+
+(c) offers the same or substantially similar functionality as the Licensed Work.
+
+5. Redistribution Requirements
+
+Redistribution in source or binary form, with or without modification, is
+permitted provided that the following conditions are met:
+
+(a) You must give any recipients of the Licensed Work a copy of this License.
+
+(b) You must cause any modified files to carry prominent notices stating that
+    you changed the files.
+
+(c) You must retain, in the source form of any derivative works, all copyright,
+    patent, trademark, and attribution notices from the source form of the
+    Licensed Work, excluding those notices that do not pertain to any part of
+    the derivative works.
+
+(d) You may not remove or alter any license notices, including copyright
+    notices, patent notices, disclaimers of warranty, or limitations of
+    liability, contained within the source form of the Licensed Work.
+
+6. Covenants
+
+Each contributor to the Licensed Work covenants that they have the right to
+grant the license set out in this License.
+
+7. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Licensed Work.
+
+8. Disclaimer of Warranty
+
+To the maximum extent permitted by applicable law, the Licensed Work is provided
+"as is" and "as available", without warranties or conditions of any kind,
+whether express, implied or statutory.
+
+To the maximum extent permitted by applicable law, Licensor disclaims all
+warranties and conditions, including any implied warranties or conditions of
+merchantability, fitness for a particular purpose, title, non-infringement,
+accuracy, availability, security or reliability.
+
+9. Limitation of Liability
+
+To the maximum extent permitted by applicable law, Licensor will not be liable
+for any direct, indirect, incidental, special, consequential, exemplary or
+punitive damages, or for any loss of profits, revenue, goodwill, data, business
+opportunities or anticipated savings, arising out of or in connection with the
+Licensed Work or this License.
+
+10. Termination
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work. Upon termination, you must immediately cease all use and
+distribution of the Licensed Work, destroy all copies of the Licensed Work in
+your possession or control, and upon Licensor's request, certify such
+destruction in writing. Termination does not affect any rights or obligations
+that by their nature are intended to survive termination, including sections
+titled "Disclaimer of Warranty," "Limitation of Liability," "Indemnification,"
+and "Termination".
+
+11. Indemnification
+
+You shall indemnify, defend, and hold harmless Licensor and its officers,
+directors, employees, and agents from and against any claims, damages, losses,
+liabilities, costs, and expenses (including reasonable legal fees) arising out of
+or in connection with your use of the Licensed Work or any breach of this
+License.
+
+12. Transition to Change License
+
+On the Change Date, the Terms and Conditions of this License, including the Use
+Limitation and the Competing Use restriction, shall cease to apply to the
+applicable version of the Licensed Work, and such version shall thereafter be
+available under the Change License. Each version of the Licensed Work has its own
+Change Date, calculated from the date that specific version was first made
+available by Licensor.
+
+13. Separate Mobile SDK License
+
+The Codemagic Mobile SDK is not covered by this License. The Mobile SDK is made
+available under the Apache License, Version 2.0, as separately documented in the
+Mobile SDK repository. The Mobile SDK may not be used to circumvent or avoid the
+restrictions of this License as applied to the Licensed Work.
+
+14. Governing Law and Jurisdiction
+
+This License shall be governed by and construed in accordance with the laws of
+the Republic of Estonia, without regard to its conflict of laws principles. Any
+disputes arising out of or in connection with this License shall be submitted to
+the exclusive jurisdiction of the courts of the Republic of Estonia.

--- a/examples/LICENSE
+++ b/examples/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nevercode Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "codemagic-patch-monorepo",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE",
   "packageManager": "yarn@4.12.0",
   "workspaces": [
     "cli",

--- a/server/LICENSE
+++ b/server/LICENSE
@@ -1,0 +1,188 @@
+Codemagic Server License
+(Based on Functional Source License, Version 1.1)
+
+Abbreviation
+
+Codemagic-FSL-1.1-Apache-2.0
+
+Notice
+
+Copyright (C) 2026 Nevercode Ltd
+
+TERMS AND CONDITIONS
+
+1. Definitions
+
+"Licensor"
+
+Nevercode Ltd, a company incorporated under the laws of England and Wales in
+the UK, Company number 10577696, with its registered address at Lytchett House,
+Wareham Road, Poole, Dorset, England, BH16 6FA, UK.
+
+"You" or "your"
+
+The individual or legal entity exercising rights under this License.
+
+"Licensed Work"
+
+Codemagic Patch, including all source code, documentation, and associated files
+made available by Licensor under this License. The software is Copyright (C) 2026
+Nevercode Ltd.
+
+"Change License"
+
+Apache License, Version 2.0
+
+"Change Date"
+
+Two (2) years from the date the Licensed Work is made available under this
+License. Each separately published version of the Licensed Work has its own
+Change Date. On the Change Date, or if Licensor publicly posts a later Change
+Date for a given version, the later of the two dates, the Licensed Work will
+become available under the Change License.
+
+2. License Grant
+
+Subject to the Terms and Conditions of this License, Licensor hereby grants you
+a non-exclusive, worldwide, royalty-free license to use, copy, modify, create
+derivative works, and redistribute the Licensed Work, subject to the Use
+Limitation and the Competing Use restriction set out below.
+
+All rights in the Licensed Work not expressly granted herein are reserved by
+Licensor.
+
+3. Use Limitation
+
+3.1. Free Use
+
+The Licensed Work may be used free of charge, provided that the total number of
+unique devices that request an update from the Licensed Work in any calendar
+month ("Monthly Active Users") does not exceed one million (1,000,000).
+
+3.2. Commercial Use
+
+If Monthly Active Users exceeds this threshold in any calendar month, you must,
+before continuing such use in the following calendar month, either obtain a
+separate commercial license from Licensor or cease all use of the Licensed Work.
+
+3.3. Measurement of Use
+
+Monthly Active Users is measured by counting each unique device identifier that
+initiates at least one update request to the Licensed Work during a given
+calendar month. A device that requests multiple updates within the same calendar
+month is counted only once.
+
+4. Use Restrictions
+
+4.1. Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. Permitted
+Purposes specifically include using the Licensed Work: (a) for your own internal
+use and access; (b) for non-commercial education; (c) for non-commercial
+research; and (d) in connection with professional services that you provide to a
+licensee using the Licensed Work in accordance with these Terms and Conditions.
+
+4.2. Competing Use
+
+A Competing Use means making the Licensed Work available to others in a
+commercial product or service that:
+
+(a) substitutes for the Licensed Work;
+
+(b) substitutes for any other product or service offered by Licensor using the
+    Licensed Work that exists as of the date the Licensed Work is made available
+    under this License; or
+
+(c) offers the same or substantially similar functionality as the Licensed Work.
+
+5. Redistribution Requirements
+
+Redistribution in source or binary form, with or without modification, is
+permitted provided that the following conditions are met:
+
+(a) You must give any recipients of the Licensed Work a copy of this License.
+
+(b) You must cause any modified files to carry prominent notices stating that
+    you changed the files.
+
+(c) You must retain, in the source form of any derivative works, all copyright,
+    patent, trademark, and attribution notices from the source form of the
+    Licensed Work, excluding those notices that do not pertain to any part of
+    the derivative works.
+
+(d) You may not remove or alter any license notices, including copyright
+    notices, patent notices, disclaimers of warranty, or limitations of
+    liability, contained within the source form of the Licensed Work.
+
+6. Covenants
+
+Each contributor to the Licensed Work covenants that they have the right to
+grant the license set out in this License.
+
+7. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Licensed Work.
+
+8. Disclaimer of Warranty
+
+To the maximum extent permitted by applicable law, the Licensed Work is provided
+"as is" and "as available", without warranties or conditions of any kind,
+whether express, implied or statutory.
+
+To the maximum extent permitted by applicable law, Licensor disclaims all
+warranties and conditions, including any implied warranties or conditions of
+merchantability, fitness for a particular purpose, title, non-infringement,
+accuracy, availability, security or reliability.
+
+9. Limitation of Liability
+
+To the maximum extent permitted by applicable law, Licensor will not be liable
+for any direct, indirect, incidental, special, consequential, exemplary or
+punitive damages, or for any loss of profits, revenue, goodwill, data, business
+opportunities or anticipated savings, arising out of or in connection with the
+Licensed Work or this License.
+
+10. Termination
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work. Upon termination, you must immediately cease all use and
+distribution of the Licensed Work, destroy all copies of the Licensed Work in
+your possession or control, and upon Licensor's request, certify such
+destruction in writing. Termination does not affect any rights or obligations
+that by their nature are intended to survive termination, including sections
+titled "Disclaimer of Warranty," "Limitation of Liability," "Indemnification,"
+and "Termination".
+
+11. Indemnification
+
+You shall indemnify, defend, and hold harmless Licensor and its officers,
+directors, employees, and agents from and against any claims, damages, losses,
+liabilities, costs, and expenses (including reasonable legal fees) arising out of
+or in connection with your use of the Licensed Work or any breach of this
+License.
+
+12. Transition to Change License
+
+On the Change Date, the Terms and Conditions of this License, including the Use
+Limitation and the Competing Use restriction, shall cease to apply to the
+applicable version of the Licensed Work, and such version shall thereafter be
+available under the Change License. Each version of the Licensed Work has its own
+Change Date, calculated from the date that specific version was first made
+available by Licensor.
+
+13. Separate Mobile SDK License
+
+The Codemagic Mobile SDK is not covered by this License. The Mobile SDK is made
+available under the Apache License, Version 2.0, as separately documented in the
+Mobile SDK repository. The Mobile SDK may not be used to circumvent or avoid the
+restrictions of this License as applied to the Licensed Work.
+
+14. Governing Law and Jurisdiction
+
+This License shall be governed by and construed in accordance with the laws of
+the Republic of Estonia, without regard to its conflict of laws principles. Any
+disputes arising out of or in connection with this License shall be submitted to
+the exclusive jurisdiction of the courts of the Republic of Estonia.

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@codemagic/patch-server",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/shared/LICENSE
+++ b/shared/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nevercode Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@codemagic/patch-shared",
   "private": true,
+  "license": "Apache-2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/web-dashboard/LICENSE
+++ b/web-dashboard/LICENSE
@@ -1,0 +1,188 @@
+Codemagic Server License
+(Based on Functional Source License, Version 1.1)
+
+Abbreviation
+
+Codemagic-FSL-1.1-Apache-2.0
+
+Notice
+
+Copyright (C) 2026 Nevercode Ltd
+
+TERMS AND CONDITIONS
+
+1. Definitions
+
+"Licensor"
+
+Nevercode Ltd, a company incorporated under the laws of England and Wales in
+the UK, Company number 10577696, with its registered address at Lytchett House,
+Wareham Road, Poole, Dorset, England, BH16 6FA, UK.
+
+"You" or "your"
+
+The individual or legal entity exercising rights under this License.
+
+"Licensed Work"
+
+Codemagic Patch, including all source code, documentation, and associated files
+made available by Licensor under this License. The software is Copyright (C) 2026
+Nevercode Ltd.
+
+"Change License"
+
+Apache License, Version 2.0
+
+"Change Date"
+
+Two (2) years from the date the Licensed Work is made available under this
+License. Each separately published version of the Licensed Work has its own
+Change Date. On the Change Date, or if Licensor publicly posts a later Change
+Date for a given version, the later of the two dates, the Licensed Work will
+become available under the Change License.
+
+2. License Grant
+
+Subject to the Terms and Conditions of this License, Licensor hereby grants you
+a non-exclusive, worldwide, royalty-free license to use, copy, modify, create
+derivative works, and redistribute the Licensed Work, subject to the Use
+Limitation and the Competing Use restriction set out below.
+
+All rights in the Licensed Work not expressly granted herein are reserved by
+Licensor.
+
+3. Use Limitation
+
+3.1. Free Use
+
+The Licensed Work may be used free of charge, provided that the total number of
+unique devices that request an update from the Licensed Work in any calendar
+month ("Monthly Active Users") does not exceed one million (1,000,000).
+
+3.2. Commercial Use
+
+If Monthly Active Users exceeds this threshold in any calendar month, you must,
+before continuing such use in the following calendar month, either obtain a
+separate commercial license from Licensor or cease all use of the Licensed Work.
+
+3.3. Measurement of Use
+
+Monthly Active Users is measured by counting each unique device identifier that
+initiates at least one update request to the Licensed Work during a given
+calendar month. A device that requests multiple updates within the same calendar
+month is counted only once.
+
+4. Use Restrictions
+
+4.1. Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. Permitted
+Purposes specifically include using the Licensed Work: (a) for your own internal
+use and access; (b) for non-commercial education; (c) for non-commercial
+research; and (d) in connection with professional services that you provide to a
+licensee using the Licensed Work in accordance with these Terms and Conditions.
+
+4.2. Competing Use
+
+A Competing Use means making the Licensed Work available to others in a
+commercial product or service that:
+
+(a) substitutes for the Licensed Work;
+
+(b) substitutes for any other product or service offered by Licensor using the
+    Licensed Work that exists as of the date the Licensed Work is made available
+    under this License; or
+
+(c) offers the same or substantially similar functionality as the Licensed Work.
+
+5. Redistribution Requirements
+
+Redistribution in source or binary form, with or without modification, is
+permitted provided that the following conditions are met:
+
+(a) You must give any recipients of the Licensed Work a copy of this License.
+
+(b) You must cause any modified files to carry prominent notices stating that
+    you changed the files.
+
+(c) You must retain, in the source form of any derivative works, all copyright,
+    patent, trademark, and attribution notices from the source form of the
+    Licensed Work, excluding those notices that do not pertain to any part of
+    the derivative works.
+
+(d) You may not remove or alter any license notices, including copyright
+    notices, patent notices, disclaimers of warranty, or limitations of
+    liability, contained within the source form of the Licensed Work.
+
+6. Covenants
+
+Each contributor to the Licensed Work covenants that they have the right to
+grant the license set out in this License.
+
+7. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Licensed Work.
+
+8. Disclaimer of Warranty
+
+To the maximum extent permitted by applicable law, the Licensed Work is provided
+"as is" and "as available", without warranties or conditions of any kind,
+whether express, implied or statutory.
+
+To the maximum extent permitted by applicable law, Licensor disclaims all
+warranties and conditions, including any implied warranties or conditions of
+merchantability, fitness for a particular purpose, title, non-infringement,
+accuracy, availability, security or reliability.
+
+9. Limitation of Liability
+
+To the maximum extent permitted by applicable law, Licensor will not be liable
+for any direct, indirect, incidental, special, consequential, exemplary or
+punitive damages, or for any loss of profits, revenue, goodwill, data, business
+opportunities or anticipated savings, arising out of or in connection with the
+Licensed Work or this License.
+
+10. Termination
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other versions
+of the Licensed Work. Upon termination, you must immediately cease all use and
+distribution of the Licensed Work, destroy all copies of the Licensed Work in
+your possession or control, and upon Licensor's request, certify such
+destruction in writing. Termination does not affect any rights or obligations
+that by their nature are intended to survive termination, including sections
+titled "Disclaimer of Warranty," "Limitation of Liability," "Indemnification,"
+and "Termination".
+
+11. Indemnification
+
+You shall indemnify, defend, and hold harmless Licensor and its officers,
+directors, employees, and agents from and against any claims, damages, losses,
+liabilities, costs, and expenses (including reasonable legal fees) arising out of
+or in connection with your use of the Licensed Work or any breach of this
+License.
+
+12. Transition to Change License
+
+On the Change Date, the Terms and Conditions of this License, including the Use
+Limitation and the Competing Use restriction, shall cease to apply to the
+applicable version of the Licensed Work, and such version shall thereafter be
+available under the Change License. Each version of the Licensed Work has its own
+Change Date, calculated from the date that specific version was first made
+available by Licensor.
+
+13. Separate Mobile SDK License
+
+The Codemagic Mobile SDK is not covered by this License. The Mobile SDK is made
+available under the Apache License, Version 2.0, as separately documented in the
+Mobile SDK repository. The Mobile SDK may not be used to circumvent or avoid the
+restrictions of this License as applied to the Licensed Work.
+
+14. Governing Law and Jurisdiction
+
+This License shall be governed by and construed in accordance with the laws of
+the Republic of Estonia, without regard to its conflict of laws principles. Any
+disputes arising out of or in connection with this License shall be submitted to
+the exclusive jurisdiction of the courts of the Republic of Estonia.

--- a/web-dashboard/package.json
+++ b/web-dashboard/package.json
@@ -1,6 +1,7 @@
 {
   "name": "web-dashboard",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE",
   "version": "0.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Adds explicit license terms across the repository so consumers and license scanners no longer have to infer them.

- Add the root **Codemagic Server License** (`LICENSE`) and a human-readable `LICENSING.md` that documents how each component is licensed.
- Add per-component `LICENSE` files:
  - **Apache-2.0** — `client/`, `cli/`, `shared/`, `examples/`
  - **Codemagic Server License** — `server/`, `web-dashboard/`, `deploy/`
- Declare `"license"` in each package manifest (`Apache-2.0`, or `SEE LICENSE IN LICENSE` for Server-License components) and switch the client podspec from `MIT` to `Apache-2.0`.
