### PR TITLE
chore(client): add npm publish metadata and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This monorepo contains everything you need to run the service yourself and wire 
                                    └─────────┘
 ```
 
-1. You publish a release with the CLI. The server bundles your JS, computes a native **fingerprint** and a target **binary version**, then stores the artifact and a manifest in object storage.
+1. You publish a release with the CLI. It bundles your JS, computes a native **fingerprint**, resolves a target **binary version**, and uploads the bundle to the server, which stores the artifact and a manifest in object storage.
 2. On launch (or resume), the SDK fetches the manifest for its deployment + binary version, downloads the new bundle (or a smaller **binary patch** when available), and swaps it in on the next restart.
 3. The SDK reports download/install/success/failure metrics back to the server.
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Add the config plugin to `app.json` / `app.config.js`:
   "expo": {
     "plugins": [
       [
-        "@codemagic/react-native-patch/app.plugin.js",
+        "@codemagic/react-native-patch",
         {
           "ios": {
             "deploymentKey": "ios-staging-deployment-key",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Codemagic Patch is a **self-hosted over-the-air (OTA) update service for React N
 This monorepo contains everything you need to run the service yourself and wire it into an app:
 
 - a **server** (control plane + release worker),
-- a **React Native client SDK** (`@codemagic/patch-client`) with an Expo config plugin,
+- a **React Native client SDK** (`@codemagic/react-native-patch`) with an Expo config plugin,
 - a **CLI** (`cmpatch`) for publishing and managing releases,
 - a **web dashboard**, and
 - a one-command **Docker Compose self-host** stack.
@@ -38,8 +38,8 @@ This monorepo contains everything you need to run the service yourself and wire 
 ```
   Developer / CI                Self-host server                 Installed app
  ┌──────────────┐   release    ┌──────────────────┐   manifest  ┌──────────────┐
- │   cmpatch    │ ───────────► │  API + worker    │ ◄────────── │  patch-client│
- │  release-... │   upload     │  (Fastify)       │   download  │   SDK (RN)   │
+ │   cmpatch    │ ───────────► │  API + worker    │ ◄────────── │ react-native │
+ │  release-... │   upload     │  (Fastify)       │   download  │  -patch SDK  │
  └──────────────┘              │  Postgres + S3   │ ──────────► │  swaps bundle│
                                └──────────────────┘   artifacts └──────────────┘
                                         ▲
@@ -84,7 +84,7 @@ The default self-host stack runs four services on a single Docker host:
 | Path               | Package                   | Description                                                          |
 | ------------------ | ------------------------- | ------------------------------------------------------------------- |
 | `server/`          | `@codemagic/patch-server` | Fastify API + release/manifest worker                               |
-| `client/`          | `@codemagic/patch-client` | React Native SDK + Expo config plugin (`app.plugin.js`)             |
+| `client/`          | `@codemagic/react-native-patch` | React Native SDK + Expo config plugin (`app.plugin.js`)             |
 | `cli/`             | `codemagic-patch`         | The `cmpatch` CLI                                                    |
 | `web-dashboard/`   | `web-dashboard`           | React SPA dashboard (served by Caddy)                               |
 | `shared/`          | `@codemagic/patch-shared` | Types and helpers shared across packages                            |
@@ -256,7 +256,7 @@ cmpatch deployment list --app MyApp-Android --format table
 Add the SDK:
 
 ```bash
-yarn add @codemagic/patch-client
+yarn add @codemagic/react-native-patch
 ```
 
 The SDK is configured through four native values (injected at build time):
@@ -323,7 +323,7 @@ Add the config plugin to `app.json` / `app.config.js`:
   "expo": {
     "plugins": [
       [
-        "@codemagic/patch-client/app.plugin.js",
+        "@codemagic/react-native-patch/app.plugin.js",
         {
           "ios": {
             "deploymentKey": "ios-staging-deployment-key",
@@ -374,7 +374,7 @@ Call `sync()` once, as early as possible after your root component mounts. This 
 ```tsx
 // App.tsx
 import { useEffect } from "react";
-import { sync } from "@codemagic/patch-client";
+import { sync } from "@codemagic/react-native-patch";
 
 export default function App() {
   useEffect(() => {
@@ -411,7 +411,7 @@ void sync({
 >
 > ```ts
 > import { AppState } from "react-native";
-> import { sync } from "@codemagic/patch-client";
+> import { sync } from "@codemagic/react-native-patch";
 >
 > AppState.addEventListener("change", (next) => {
 >   if (next === "active") void sync();
@@ -424,7 +424,7 @@ void sync({
 
 ```tsx
 import { useEffect, useState } from "react";
-import { sync, type SyncStatus } from "@codemagic/patch-client";
+import { sync, type SyncStatus } from "@codemagic/react-native-patch";
 
 export function useOtaUpdate() {
   const [progress, setProgress] = useState(0);
@@ -473,7 +473,7 @@ import {
   restartApp,
   disallowRestart,
   allowRestart,
-} from "@codemagic/patch-client";
+} from "@codemagic/react-native-patch";
 
 // 1) Confirm the running bundle is healthy (arms rollback). Call this once on
 //    startup if you are NOT using sync(), e.g. after your app finishes booting.

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,130 @@
+# `@codemagic/react-native-patch`
+
+React Native client SDK for [**Codemagic Patch**](https://github.com/codemagic-ci-cd/codemagic-patch) — a self-hosted over-the-air (OTA) update service for React Native apps. Ship JavaScript and asset updates straight to installed apps, with no app-store review for changes that live in your JS bundle.
+
+This SDK downloads, verifies, and boots update bundles on device. It pairs with the Codemagic Patch server and the [`codemagic-patch` CLI](https://github.com/codemagic-ci-cd/codemagic-patch); see the [main repository](https://github.com/codemagic-ci-cd/codemagic-patch) for the server, protocol, and self-hosting guide.
+
+## Requirements
+
+- React Native `0.76+` — Old Architecture and New Architecture
+- Android native build with CMake/JNI support
+- iOS native build with CocoaPods and mixed Swift/ObjC++ compilation
+- Expo SDK 52+ (via the bundled config plugin — see [Expo apps](#expo-apps))
+- **Expo Go is not supported** — the native module is not part of the Expo Go runtime
+
+## Installation
+
+```sh
+npm install @codemagic/react-native-patch
+# or
+yarn add @codemagic/react-native-patch
+```
+
+`react` (`>=18`) and `react-native` (`>=0.76`) are peer dependencies. On iOS, install the native pod:
+
+```sh
+cd ios && pod install
+```
+
+## Configuration
+
+Codemagic Patch is configured through **native resources**, not a JS API — the deployment key, URLs, public key, and binary version are read natively before the SDK initializes. Provide these values per host app:
+
+| Resource | Required | Meaning |
+| --- | --- | --- |
+| `CodemagicPatchDeploymentKey` | yes | Deployment key for this app/track |
+| `CodemagicPatchApiUrl` | yes | API server origin (the server's `SERVER_URL`), e.g. `https://updates.example.com`. The SDK appends `/v1/...` |
+| `CodemagicPatchDownloadBaseUrl` | yes | Artifact origin (the server's `PUBLIC_BASE_URL`), e.g. `https://storage.example.com/codemagic-patch`. May include a bucket/path prefix; the SDK appends manifest/artifact paths |
+| `CodemagicPatchPublicKey` | no | PEM public key; required only when enforcing client-side signature verification |
+
+The two URLs point at different systems (API server vs. object storage / CDN), which is why one usually carries a path and the other does not.
+
+### Bare React Native
+
+1. **Declare the resources.** Add the keys above to Android `strings.xml` and iOS `Info.plist`.
+
+2. **Wire native bundle selection** before the RN bridge starts, so boot order is **pending package → current package → embedded bundle**.
+
+   Android — feed `CodemagicPatch.getJSBundleFile(applicationContext)` into React Native in `MainApplication`. On RN ≤ 0.81 (`ReactNativeHost`), override `getJSBundleFile()`:
+
+   ```kotlin
+   override fun getJSBundleFile(): String? =
+       CodemagicPatch.getJSBundleFile(applicationContext)
+   ```
+
+   On RN 0.82+ (new-arch `reactHost`), pass it as `jsBundleFilePath`:
+
+   ```kotlin
+   override val reactHost: ReactHost by lazy {
+     getDefaultReactHost(
+       context = applicationContext,
+       packageList = PackageList(this).packages,
+       jsBundleFilePath = CodemagicPatch.getJSBundleFile(applicationContext),
+     )
+   }
+   ```
+
+   iOS — override `bundleURL()` / `sourceURL(for:)` in `AppDelegate` with the same selection order:
+
+   ```swift
+   override func bundleURL() -> URL? {
+     if let otaBundle = CodemagicPatch.bundleURL() {
+       return otaBundle
+     }
+     return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+   }
+   ```
+
+   Expected embedded bundle names are `index.android.bundle` (Android) and `main.jsbundle` (iOS). If the SDK cannot determine a non-blank binary version (`versionName` / `CFBundleShortVersionString`), it no-ops and falls back to the embedded bundle.
+
+3. **Register the native module** for your architecture — the TurboModule (New Architecture) or the bridge module/package (Old Architecture). Autolinking handles this in most apps.
+
+### Expo apps
+
+The package ships a bundled Expo config plugin (`app.plugin.js`). Add it to `app.json` with per-platform props and run `expo prebuild`:
+
+```json
+{
+  "plugins": [
+    ["@codemagic/react-native-patch", {
+      "ios":     { "deploymentKey": "<key>", "downloadBaseUrl": "<url>", "apiUrl": "<url>", "publicKey": "<pem>" },
+      "android": { "deploymentKey": "<key>", "downloadBaseUrl": "<url>", "apiUrl": "<url>", "publicKey": "<pem>" }
+    }]
+  ]
+}
+```
+
+The plugin writes the native resources and wires bundle selection automatically (Configuration steps 1–3). Configure **at least one platform**, and complete every block you provide — `deploymentKey`, `downloadBaseUrl`, and `apiUrl` are all required per block (`publicKey` is optional). The plugin resolves `expo/config-plugins` from your app's own Expo SDK, so there is nothing extra to install; `expo` is not a runtime or peer dependency of this package.
+
+## Usage
+
+The simplest integration is `sync()`, which checks for an update, downloads it, installs it, and reports app readiness in one call. It never throws — it resolves to a status string.
+
+```ts
+import { sync } from "@codemagic/react-native-patch";
+
+const status = await sync();
+// "update-installed" | "up-to-date" | "embedded-revert-applied"
+// | "sync-in-progress" | "error"
+```
+
+For finer control, drive the steps yourself and call `notifyAppReady()` once the app has started successfully (so the update is not rolled back):
+
+```ts
+import {
+  checkForUpdate,
+  downloadUpdate,
+  installUpdate,
+  notifyAppReady,
+} from "@codemagic/react-native-patch";
+```
+
+`restartApp`, `allowRestart` / `disallowRestart`, and `hydrate` are also exported for controlling reload timing. See the [type definitions](https://github.com/codemagic-ci-cd/codemagic-patch/tree/main/client/src/types.ts) for the full API surface.
+
+## Documentation
+
+Full integration guide, update protocol, and self-hosting instructions live in the [Codemagic Patch repository](https://github.com/codemagic-ci-cd/codemagic-patch).
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/client/app.plugin.js
+++ b/client/app.plugin.js
@@ -1,4 +1,4 @@
-// Expo config-plugin entry point. Expo resolves `@codemagic/patch-client/app.plugin.js`
+// Expo config-plugin entry point. Expo resolves `@codemagic/react-native-patch/app.plugin.js`
 // (bypassing the package `exports` map only when `./app.plugin.js` is exported —
 // which it is). Points at the compiled plugin. The `prepare` script builds
 // `plugin/build` on install/pack/publish; source consumers (portal:/workspace:)

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,30 @@
 {
-  "name": "@codemagic/patch-client",
-  "version": "0.0.0",
+  "name": "@codemagic/react-native-patch",
+  "version": "0.1.0",
+  "description": "React Native client SDK for Codemagic Patch — over-the-air JavaScript & asset updates for React Native and Expo apps.",
+  "keywords": [
+    "react-native",
+    "expo",
+    "ota",
+    "over-the-air",
+    "code-push",
+    "hot-update",
+    "codemagic",
+    "codemagic-patch"
+  ],
   "license": "Apache-2.0",
+  "homepage": "https://github.com/codemagic-ci-cd/codemagic-patch/tree/main/client#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/codemagic-ci-cd/codemagic-patch.git",
+    "directory": "client"
+  },
+  "bugs": {
+    "url": "https://github.com/codemagic-ci-cd/codemagic-patch/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "react-native": "./src/index.ts",

--- a/client/plugin/src/types.ts
+++ b/client/plugin/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Public prop shape for the `@codemagic/patch-client` Expo config plugin.
+ * Public prop shape for the `@codemagic/react-native-patch` Expo config plugin.
  *
  * Deployment keys differ per platform, so the plugin takes a separate config
  * block for iOS and Android. Each block is written verbatim into the native

--- a/client/plugin/src/validateConfig.ts
+++ b/client/plugin/src/validateConfig.ts
@@ -36,7 +36,7 @@ export function assertPlatformConfig(
   if (missing.length > 0) {
     throw new Error(
       `[codemagic-patch] ${platform} config is missing required value(s): ${missing.join(', ')}. ` +
-        `Set them in app config under plugins → "@codemagic/patch-client" → ${platform} ` +
+        `Set them in app config under plugins → "@codemagic/react-native-patch" → ${platform} ` +
         `(deploymentKey, downloadBaseUrl, and apiUrl are all required; publicKey is optional). ` +
         `To disable OTA for ${platform}, omit the ${platform} block entirely.`,
     );
@@ -56,7 +56,7 @@ export function validatePluginProps(props: CodemagicPatchPluginProps): void {
   if (!props.ios && !props.android) {
     throw new Error(
       `[codemagic-patch] no platform is configured. Provide an "ios" and/or "android" block under ` +
-        `plugins → "@codemagic/patch-client" (each with deploymentKey, downloadBaseUrl, and apiUrl). ` +
+        `plugins → "@codemagic/react-native-patch" (each with deploymentKey, downloadBaseUrl, and apiUrl). ` +
         `At least one platform is required.`,
     );
   }

--- a/client/plugin/src/withCodemagicPatch.ts
+++ b/client/plugin/src/withCodemagicPatch.ts
@@ -23,7 +23,7 @@ import { withAndroidBundleFile } from './withAndroidBundleFile';
 import { withAndroidConfig } from './withAndroidConfig';
 
 /**
- * Expo config plugin for `@codemagic/patch-client`.
+ * Expo config plugin for `@codemagic/react-native-patch`.
  *
  * Adds, at prebuild time, the native bundle-selection seam the SDK needs (the
  * one bare-RN hosts wire by hand) plus the per-platform CodemagicPatch config values.
@@ -37,11 +37,11 @@ const withCodemagicPatch: ConfigPlugin<CodemagicPatchPluginProps> = (config, pro
   const plugins: Parameters<typeof withPlugins>[1] = [];
 
   if (props.ios) {
-    plugins.push(createRunOncePlugin(withIosBundleURL, '@codemagic/patch-client:ios-bundle'));
+    plugins.push(createRunOncePlugin(withIosBundleURL, '@codemagic/react-native-patch:ios-bundle'));
     plugins.push([withIosConfig, props.ios]);
   }
   if (props.android) {
-    plugins.push(createRunOncePlugin(withAndroidBundleFile, '@codemagic/patch-client:android-bundle'));
+    plugins.push(createRunOncePlugin(withAndroidBundleFile, '@codemagic/react-native-patch:android-bundle'));
     plugins.push([withAndroidConfig, props.android]);
   }
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,8 +6,8 @@
     "rootDir": ".",
     "baseUrl": ".",
     "paths": {
-      "@codemagic/patch-client": ["./src/index.ts"],
-      "@codemagic/patch-client/testing": ["./testing.ts"]
+      "@codemagic/react-native-patch": ["./src/index.ts"],
+      "@codemagic/react-native-patch/testing": ["./testing.ts"]
     },
     "tsBuildInfoFile": "./node_modules/.cache/tsconfig.tsbuildinfo"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,9 +1929,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemagic/patch-client@workspace:client":
+"@codemagic/react-native-patch@workspace:client":
   version: 0.0.0-use.local
-  resolution: "@codemagic/patch-client@workspace:client"
+  resolution: "@codemagic/react-native-patch@workspace:client"
   dependencies:
     eslint: "npm:^9.36.0"
     expo: "npm:~56.0.9"


### PR DESCRIPTION
Prepare the React Native client SDK for its first npm publish (v0.1.0):

- Rename: `@codemagic/patch-client` → `@codemagic/react-native-patch`
- package.json: bump version 0.0.0 -> 0.1.0; add description, keywords, homepage, repository (directory: client), bugs, and publishConfig.access=public (required for the scoped package to publish publicly).
- README.md: npm-facing integration guide (install, native configuration, Expo plugin, sync()/manual usage). Replaces the internal guide's repo-relative spec links with absolute GitHub URLs.
