### PR TITLE
Notes in release table

### DIFF
--- a/web-dashboard/src/cli/buildReleaseReactCommand.ts
+++ b/web-dashboard/src/cli/buildReleaseReactCommand.ts
@@ -9,6 +9,7 @@ export interface ReleaseReactCommandInput {
   deploymentName: string;
   platform: ReleaseReactPlatform;
   targetBinaryVersion?: string;
+  releaseNotes?: string;
   rolloutPercentage?: number;
   mandatory?: boolean;
   disabled?: boolean;
@@ -48,6 +49,8 @@ export function buildReleaseReactCommand(
   if (targetVersion !== undefined && targetVersion.length > 0) {
     pushFlag(parts, "target-binary-version", targetVersion);
   }
+
+  pushFlag(parts, "release-notes", input.releaseNotes);
 
   const rollout = input.rolloutPercentage ?? 100;
   if (rollout !== 100) {

--- a/web-dashboard/src/components/ui/CliCommandBuilder.tsx
+++ b/web-dashboard/src/components/ui/CliCommandBuilder.tsx
@@ -88,6 +88,7 @@ export function CliCommandBuilder({
   const [targetBinaryVersion, setTargetBinaryVersion] = useState(
     suggestedTargetBinaryVersion,
   );
+  const [releaseNotes, setReleaseNotes] = useState("");
   const [rolloutPercentage, setRolloutPercentage] = useState("100");
   const [mandatory, setMandatory] = useState(false);
   const [disabled, setDisabled] = useState(false);
@@ -118,6 +119,7 @@ export function CliCommandBuilder({
         deploymentName,
         platform,
         targetBinaryVersion,
+        releaseNotes,
         rolloutPercentage: rollout,
         mandatory,
         disabled,
@@ -130,6 +132,7 @@ export function CliCommandBuilder({
       deploymentName,
       platform,
       targetBinaryVersion,
+      releaseNotes,
       rollout,
       mandatory,
       disabled,
@@ -230,6 +233,19 @@ export function CliCommandBuilder({
             </div>
           </label>
         ) : null}
+
+        <label className={`${BUILDER_FIELD} min-w-[12rem] flex-1 basis-full`}>
+          <span className={BUILDER_LABEL}>Release note</span>
+          <div className={BUILDER_CONTROL}>
+            <input
+              type="text"
+              className={`${BUILDER_INPUT} ${INPUT_STATE.normal} w-full`}
+              value={releaseNotes}
+              placeholder="What changed in this release? (optional)"
+              onChange={(event) => setReleaseNotes(event.target.value)}
+            />
+          </div>
+        </label>
       </div>
 
       <div className="flex flex-wrap gap-x-4 gap-y-2 text-[13px] text-fg">

--- a/web-dashboard/src/components/ui/RolloutBar.tsx
+++ b/web-dashboard/src/components/ui/RolloutBar.tsx
@@ -8,8 +8,14 @@
 
 export const ROLLOUT = "flex min-w-[130px] items-center gap-2.5";
 
+export const ROLLOUT_COMPACT =
+  "inline-flex w-[65px] items-center gap-1.5";
+
 export const ROLLOUT_TRACK =
   "h-[7px] flex-1 overflow-hidden rounded-pill bg-surface-3";
+
+export const ROLLOUT_TRACK_COMPACT =
+  "h-[7px] w-[22px] shrink-0 overflow-hidden rounded-pill bg-surface-3";
 
 export const ROLLOUT_FILL =
   "h-full rounded-pill bg-[linear-gradient(90deg,var(--color-blue),var(--color-aqua))]";
@@ -23,17 +29,20 @@ export interface RolloutBarProps {
   percentage: number;
   /** Accessible name for the progressbar. */
   ariaLabel?: string;
+  /** Narrow layout for dense tables (~half the default width). */
+  compact?: boolean;
 }
 
 export function RolloutBar({
   percentage,
   ariaLabel = "Rollout percentage",
+  compact = false,
 }: RolloutBarProps) {
   const pct = Math.min(100, Math.max(0, Math.round(percentage)));
   return (
-    <div className={ROLLOUT}>
+    <div className={compact ? ROLLOUT_COMPACT : ROLLOUT}>
       <div
-        className={ROLLOUT_TRACK}
+        className={compact ? ROLLOUT_TRACK_COMPACT : ROLLOUT_TRACK}
         role="progressbar"
         aria-label={ariaLabel}
         aria-valuemin={0}
@@ -47,7 +56,11 @@ export function RolloutBar({
         />
       </div>
       <span
-        className="min-w-[38px] text-right font-mono text-[12px] font-semibold text-fg-2"
+        className={
+          compact
+            ? "min-w-[32px] text-right font-mono text-[11px] font-semibold text-fg-2"
+            : "min-w-[38px] text-right font-mono text-[12px] font-semibold text-fg-2"
+        }
         aria-hidden="true"
       >
         {pct}%

--- a/web-dashboard/src/pages/DeploymentDetailPage.tsx
+++ b/web-dashboard/src/pages/DeploymentDetailPage.tsx
@@ -690,7 +690,7 @@ function ReleaseRow({
           <span className="text-fg-3">—</span>
         ) : (
           <span
-            className="block truncate text-[13px] font-medium text-fg"
+            className="block max-w-[38ch] truncate text-[13px] font-medium text-fg"
             title={release.releaseNotes}
           >
             {release.releaseNotes}
@@ -962,7 +962,7 @@ function ReleaseTableSkeleton() {
                 <Skeleton width={90} variant="text" />
               </td>
               <td className={releaseHistoryCol.td.note}>
-                <Skeleton width={180} variant="text" />
+                <Skeleton width="38ch" variant="text" />
               </td>
               <td className={releaseHistoryCol.td.data}>
                 <Skeleton width={84} variant="text" />

--- a/web-dashboard/src/pages/DeploymentDetailPage.tsx
+++ b/web-dashboard/src/pages/DeploymentDetailPage.tsx
@@ -14,8 +14,8 @@
 // developer" tip per the RBAC matrix) × release status via model/release.ts
 // (canDisable/canEnable/canPatchRollout; promote = any published; the header
 // Rollback uses canRollback over the loaded rows' published count). Release
-// `status` (StatusChip) and worker `job.status` (JobBadge) render as DISTINCT
-// columns, never conflated. Lifecycle modals: every
+// `status` (StatusChip) renders in the history table; worker job status is
+// omitted from this table (see release detail for job state). Lifecycle modals: every
 // action funnels into the shared useReleaseActions coordinator's
 // `openAction(type, release)`, which mounts RolloutModal / StatusModal /
 // PromoteModal / RollbackModal. Empty history → New release CTA (CLI or bundle
@@ -39,7 +39,6 @@ import { apiServerUrl } from "../lib/cliSnippet";
 import { Copyable } from "../components/ui/Copyable";
 import { EmptyState } from "../components/ui/EmptyState";
 import { ErrorState } from "../components/ui/ErrorState";
-import { JobBadge } from "../components/ui/JobBadge";
 import { RolloutBar } from "../components/ui/RolloutBar";
 import { Skeleton } from "../components/ui/Skeleton";
 import { StatusChip } from "../components/ui/StatusChip";
@@ -56,6 +55,10 @@ import {
 } from "../model/release";
 import { useTeamRole } from "../rbac/useTeamRole";
 import { NewReleaseModal } from "./release/modals/NewReleaseModal";
+import {
+  ReleaseHistoryTableHead,
+  releaseHistoryCol,
+} from "./release/releaseHistoryTable";
 import { useReleaseActions } from "./release/modals/useReleaseActions";
 import type { ReleaseListItem } from "../api/types";
 import type { Deployment } from "../model/deployment";
@@ -77,10 +80,6 @@ import {
 } from "../components/ui/stat";
 import {
   TBL,
-  TBL_NUM,
-  TBL_RIGHT,
-  TBL_TD,
-  TBL_TH,
   TBL_TR,
   TBL_WRAP,
 } from "../components/ui/table";
@@ -277,18 +276,7 @@ function DeploymentDetail({
         <div className={TBL_WRAP}>
           <table className={TBL}>
             <thead>
-              <tr>
-                <th className={TBL_TH}>Release</th>
-                <th className={TBL_TH}>Status</th>
-                <th className={TBL_TH}>Job</th>
-                <th className={TBL_TH}>Rollout</th>
-                <th className={TBL_TH}>Target</th>
-                <th className={`${TBL_TH} ${TBL_RIGHT}`}>Active users</th>
-                <th className={`${TBL_TH} ${TBL_RIGHT}`}>Success / Failed</th>
-                <th className={TBL_TH}>
-                  <span className="sr-only">Actions</span>
-                </th>
-              </tr>
+              <ReleaseHistoryTableHead />
             </thead>
             <tbody>
               {rows.map((item) => (
@@ -615,7 +603,7 @@ function ReleaseRow({
   onAction: (action: DeploymentReleaseAction, release: Release) => void;
   resolveUser: (userId: string | null) => string | null;
 }) {
-  const { release, job, metrics } = item;
+  const { release, metrics } = item;
 
   // Status gating (model/release.ts) decides WHICH actions exist; role
   // gating decides enabled vs disabled-with-tooltip.
@@ -661,9 +649,11 @@ function ReleaseRow({
 
   return (
     <tr className={TBL_TR}>
-      <td className={TBL_TD}>
+      <td className={releaseHistoryCol.td.release}>
         <div className={CELL_MAIN}>
-          <Link to={releasePath}>{release.releaseLabel}</Link>{" "}
+          <Link className="font-semibold" to={releasePath}>
+            {release.releaseLabel}
+          </Link>{" "}
           {release.isMandatory ? (
             <span className={`${PIN} ${PIN_TONE.mandatory}`}>
               <AlertIcon />
@@ -695,42 +685,53 @@ function ReleaseRow({
           </time>
         </div>
       </td>
-      <td className={TBL_TD}>
-        <StatusChip status={release.status} />
-      </td>
-      <td className={TBL_TD}>
-        {job === null ? (
+      <td className={releaseHistoryCol.td.note}>
+        {release.releaseNotes === null || release.releaseNotes.trim() === "" ? (
           <span className="text-fg-3">—</span>
         ) : (
-          <JobBadge status={job.status} />
+          <span
+            className="block truncate text-[13px] font-medium text-fg"
+            title={release.releaseNotes}
+          >
+            {release.releaseNotes}
+          </span>
         )}
       </td>
-      <td className={TBL_TD}>
+      <td className={releaseHistoryCol.td.data}>
+        <StatusChip status={release.status} />
+      </td>
+      <td className={releaseHistoryCol.td.data}>
         <RolloutBar
           percentage={release.rolloutPercentage}
           ariaLabel={`Rollout for ${release.releaseLabel}`}
+          compact
         />
       </td>
-      <td className={TBL_TD}>
-        <code className="mono text-[12px]">
-          {release.targetBinaryVersion}
-        </code>
+      <td className={releaseHistoryCol.td.data}>
+        {release.targetBinaryVersion}
       </td>
-      <td className={`${TBL_TD} ${TBL_NUM}`}>
+      <td className={releaseHistoryCol.td.data}>
         {metrics === undefined ? (
           <span className="text-fg-3">—</span>
         ) : (
           formatCount(metrics.active)
         )}
       </td>
-      <td className={`${TBL_TD} ${TBL_NUM}`}>
+      <td className={releaseHistoryCol.td.data}>
         {metrics === undefined ? (
           <span className="text-fg-3">—</span>
         ) : (
-          `${formatCount(metrics.success)} / ${formatCount(metrics.failed)}`
+          formatCount(metrics.success)
         )}
       </td>
-      <td className={`${TBL_TD} ${TBL_RIGHT}`}>
+      <td className={releaseHistoryCol.td.data}>
+        {metrics === undefined ? (
+          <span className="text-fg-3">—</span>
+        ) : (
+          formatCount(metrics.failed)
+        )}
+      </td>
+      <td className={releaseHistoryCol.td.actions}>
         {items.length === 0 ? null : (
           <RowKebab releaseLabel={release.releaseLabel} items={items} />
         )}
@@ -952,46 +953,36 @@ function ReleaseTableSkeleton() {
     <div className={TBL_WRAP} role="status" aria-label="Loading releases">
       <table className={TBL}>
         <thead>
-          <tr>
-            <th className={TBL_TH}>Release</th>
-            <th className={TBL_TH}>Status</th>
-            <th className={TBL_TH}>Job</th>
-            <th className={TBL_TH}>Rollout</th>
-            <th className={TBL_TH}>Target</th>
-            <th className={`${TBL_TH} ${TBL_RIGHT}`}>Active users</th>
-            <th className={`${TBL_TH} ${TBL_RIGHT}`}>Success / Failed</th>
-            <th className={TBL_TH} aria-hidden="true" />
-          </tr>
+          <ReleaseHistoryTableHead actionsLabel={null} />
         </thead>
         <tbody>
           {[0, 1, 2].map((row) => (
             <tr key={row} className={TBL_TR}>
-              <td className={TBL_TD}>
-                <Skeleton width={110} variant="text" />
+              <td className={releaseHistoryCol.td.release}>
+                <Skeleton width={90} variant="text" />
               </td>
-              <td className={TBL_TD}>
+              <td className={releaseHistoryCol.td.note}>
+                <Skeleton width={180} variant="text" />
+              </td>
+              <td className={releaseHistoryCol.td.data}>
                 <Skeleton width={84} variant="text" />
               </td>
-              <td className={TBL_TD}>
-                <Skeleton width={84} variant="text" />
+              <td className={releaseHistoryCol.td.data}>
+                <Skeleton width={65} variant="text" />
               </td>
-              <td className={TBL_TD}>
-                <Skeleton width={96} variant="text" />
+              <td className={releaseHistoryCol.td.data}>
+                <Skeleton width={36} variant="text" />
               </td>
-              <td className={TBL_TD}>
-                <Skeleton width={64} variant="text" />
+              <td className={releaseHistoryCol.td.data}>
+                <Skeleton width={28} variant="text" />
               </td>
-              <td className={`${TBL_TD} ${TBL_NUM}`}>
-                <span className="flex justify-end">
-                  <Skeleton width={48} variant="text" />
-                </span>
+              <td className={releaseHistoryCol.td.data}>
+                <Skeleton width={28} variant="text" />
               </td>
-              <td className={`${TBL_TD} ${TBL_NUM}`}>
-                <span className="flex justify-end">
-                  <Skeleton width={64} variant="text" />
-                </span>
+              <td className={releaseHistoryCol.td.data}>
+                <Skeleton width={28} variant="text" />
               </td>
-              <td className={TBL_TD} />
+              <td className={releaseHistoryCol.td.actions} />
             </tr>
           ))}
         </tbody>

--- a/web-dashboard/src/pages/DeploymentDetailPage.tsx
+++ b/web-dashboard/src/pages/DeploymentDetailPage.tsx
@@ -57,6 +57,7 @@ import { useTeamRole } from "../rbac/useTeamRole";
 import { NewReleaseModal } from "./release/modals/NewReleaseModal";
 import {
   ReleaseHistoryTableHead,
+  ReleaseNoteText,
   releaseHistoryCol,
 } from "./release/releaseHistoryTable";
 import { useReleaseActions } from "./release/modals/useReleaseActions";
@@ -689,12 +690,7 @@ function ReleaseRow({
         {release.releaseNotes === null || release.releaseNotes.trim() === "" ? (
           <span className="text-fg-3">—</span>
         ) : (
-          <span
-            className="block max-w-[38ch] truncate text-[13px] font-medium text-fg"
-            title={release.releaseNotes}
-          >
-            {release.releaseNotes}
-          </span>
+          <ReleaseNoteText text={release.releaseNotes} />
         )}
       </td>
       <td className={releaseHistoryCol.td.data}>

--- a/web-dashboard/src/pages/release/releaseHistoryTable.tsx
+++ b/web-dashboard/src/pages/release/releaseHistoryTable.tsx
@@ -4,11 +4,96 @@
 // - note: single-line truncate (~38ch) on the cell text.
 // - data: shared preset for status, rollout, target, and metric columns.
 
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { TBL_TD, TBL_TH } from "../../components/ui/table";
 
 const FIT = "w-[1%] whitespace-nowrap";
 const DATA_CELL =
   "text-center font-mono text-[12.5px] tabular-nums";
+
+const NOTE_TEXT =
+  "block max-w-[38ch] truncate text-[13px] font-medium text-fg";
+
+const TIP_SHOW_DELAY_MS = 100;
+
+/** Truncated release note with a styled hover tooltip for the full text. */
+export function ReleaseNoteText({ text }: { text: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const showTipTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [truncated, setTruncated] = useState(false);
+  const [tipPos, setTipPos] = useState<{ left: number; top: number } | null>(
+    null,
+  );
+
+  const clearShowTipTimeout = () => {
+    if (showTipTimeoutRef.current !== null) {
+      clearTimeout(showTipTimeoutRef.current);
+      showTipTimeoutRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      clearShowTipTimeout();
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el === null) {
+      return;
+    }
+    const measure = () => {
+      setTruncated(el.scrollWidth > el.clientWidth);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+    };
+  }, [text]);
+
+  return (
+    <>
+      <span
+        ref={ref}
+        className={NOTE_TEXT}
+        onMouseEnter={(event) => {
+          if (!truncated) {
+            return;
+          }
+          clearShowTipTimeout();
+          const rect = event.currentTarget.getBoundingClientRect();
+          const pos = { left: rect.left, top: rect.bottom + 8 };
+          showTipTimeoutRef.current = setTimeout(() => {
+            setTipPos(pos);
+            showTipTimeoutRef.current = null;
+          }, TIP_SHOW_DELAY_MS);
+        }}
+        onMouseLeave={() => {
+          clearShowTipTimeout();
+          setTipPos(null);
+        }}
+      >
+        {text}
+      </span>
+      {truncated && tipPos !== null
+        ? createPortal(
+            <div
+              className="hover-tip"
+              role="tooltip"
+              style={{ left: tipPos.left, top: tipPos.top }}
+            >
+              {text}
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}
 
 function th(...parts: string[]): string {
   return [TBL_TH, ...parts].join(" ");

--- a/web-dashboard/src/pages/release/releaseHistoryTable.tsx
+++ b/web-dashboard/src/pages/release/releaseHistoryTable.tsx
@@ -1,0 +1,63 @@
+// Release history table layout (DeploymentDetailPage).
+//
+// - release / actions: shrink-to-content (w-[1%]).
+// - note: default width; absorbs leftover space.
+// - data: shared preset for status, rollout, target, and metric columns.
+
+import { TBL_TD, TBL_TH } from "../../components/ui/table";
+
+const FIT = "w-[1%] whitespace-nowrap";
+const DATA_CELL =
+  "text-center font-mono text-[12.5px] tabular-nums";
+
+function th(...parts: string[]): string {
+  return [TBL_TH, ...parts].join(" ");
+}
+
+function td(...parts: string[]): string {
+  return [TBL_TD, ...parts].join(" ");
+}
+
+/** th/td class presets — always use the matching pair for a column. */
+export const releaseHistoryCol = {
+  th: {
+    release: th(FIT, "!px-[12px]"),
+    note: TBL_TH,
+    data: th("!px-[10px]", "!text-center"),
+    actions: th(FIT, "!px-[8px]", "!text-center"),
+  },
+  td: {
+    release: td(FIT, "!px-[12px]"),
+    note: TBL_TD,
+    data: td("!px-[10px]", DATA_CELL),
+    actions: td(FIT, "!px-[8px]", "text-center"),
+  },
+} as const;
+
+export function ReleaseHistoryTableHead({
+  actionsLabel = "Actions",
+}: {
+  /** Pass `null` for the skeleton header (icon column, no sr-only label). */
+  actionsLabel?: string | null;
+}) {
+  return (
+    <tr>
+      <th className={releaseHistoryCol.th.release}>Release</th>
+      <th className={releaseHistoryCol.th.note}>Note</th>
+      <th className={releaseHistoryCol.th.data}>Status</th>
+      <th className={releaseHistoryCol.th.data}>Rollout</th>
+      <th className={releaseHistoryCol.th.data}>Target</th>
+      <th className={releaseHistoryCol.th.data}>Active</th>
+      <th className={releaseHistoryCol.th.data}>Success</th>
+      <th className={releaseHistoryCol.th.data}>Failed</th>
+      <th
+        className={releaseHistoryCol.th.actions}
+        aria-hidden={actionsLabel === null ? true : undefined}
+      >
+        {actionsLabel === null ? null : (
+          <span className="sr-only">{actionsLabel}</span>
+        )}
+      </th>
+    </tr>
+  );
+}

--- a/web-dashboard/src/pages/release/releaseHistoryTable.tsx
+++ b/web-dashboard/src/pages/release/releaseHistoryTable.tsx
@@ -1,7 +1,7 @@
 // Release history table layout (DeploymentDetailPage).
 //
 // - release / actions: shrink-to-content (w-[1%]).
-// - note: default width; absorbs leftover space.
+// - note: single-line truncate (~38ch) on the cell text.
 // - data: shared preset for status, rollout, target, and metric columns.
 
 import { TBL_TD, TBL_TH } from "../../components/ui/table";

--- a/web-dashboard/src/styles/app.css
+++ b/web-dashboard/src/styles/app.css
@@ -273,6 +273,22 @@
     pointer-events: none;
   }
 
+  /* Portaled tooltip (e.g. table cells inside overflow-auto). */
+  .hover-tip {
+    position: fixed;
+    z-index: 100;
+    max-width: 38ch;
+    padding: 7px 11px;
+    background: var(--color-ink);
+    color: #fff;
+    font-size: 11.5px;
+    font-weight: 400;
+    line-height: 1.45;
+    border-radius: 8px;
+    box-shadow: var(--shadow-md);
+    pointer-events: none;
+  }
+
   /* load-in stagger — gated on no-preference: base.css kills animations under
      reduced motion, which would otherwise strand children at opacity:0 forever
      (blank content for reduced-motion users). */


### PR DESCRIPTION
I figured it would be helpful for identifying releases if the `--release-note` was exposed in the table. I did some formatting tidy it up while I was at it, to more efficiently use the space in the table.

That included dropping the Job column, as I'm not sure that's needed as a scannable detail, but maybe I'm wrong.

<img width="1422" height="849" alt="image" src="https://github.com/user-attachments/assets/129c040a-6c7c-4e88-bd98-3baa850cb048" />
<br>
<br>
We could alternatively make Note the main label and have the version number more subdued, a bit like PR name and number in github's tables. But, I figured this version was a smaller step in that direction.

I also added `Release note` into the CLI command builder as I realised I had missed it out.

<img width="687" height="565" alt="image" src="https://github.com/user-attachments/assets/df804507-2b51-479e-85dc-1eef6547675e" />
