### PR TITLE
Add local evaluation quickstart and on-device demo guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,24 +14,52 @@ This monorepo contains everything you need to run the service yourself and wire 
 
 ---
 
+## Quickstart — try it locally
+
+Evaluate the full service on your machine before provisioning domains or OAuth: the **local evaluation stack** runs the real server, worker, Postgres, MinIO, and dashboard, with sign-in replaced by a local one-click login.
+
+```bash
+git clone https://github.com/codemagic-ci-cd/codemagic-patch.git
+cd codemagic-patch
+./scripts/local-eval/up.sh
+```
+
+The script brings up the stack, installs the `cmpatch` CLI globally, and prints a ready banner. You get:
+
+- **Dashboard** — <http://localhost:8080>
+- **API** — <http://localhost:3000>
+
+Watch it process and publish in the dashboard. To see an update **apply on a running app** (iOS simulator / Android emulator), continue with the [on-device demo](examples/on-device-demo/README.md).
+
+Tear everything down with:
+
+```bash
+docker compose -f docker-compose.dev.yml down -v
+```
+
+> ⚠️ **Evaluation only — not a deployment.**  To self-host for real, follow [Part 1 — Run the server (self-host)](#part-1--run-the-server-self-host).
+
+---
+
 ## Table of contents
 
-1. [How it works](#how-it-works)
-2. [Core concepts](#core-concepts)
-3. [Repository layout](#repository-layout)
-4. [Requirements](#requirements)
-5. [Part 1 — Run the server (self-host)](#part-1--run-the-server-self-host)
-6. [Part 2 — Install the CLI and sign in](#part-2--install-the-cli-and-sign-in)
-7. [Part 3 — Create apps & deployments](#part-3--create-apps--deployments)
-8. [Part 4 — Connect your React Native app](#part-4--connect-your-react-native-app)
-9. [Part 5 — Publish your first release](#part-5--publish-your-first-release)
-10. [Managing releases](#managing-releases)
-11. [Code signing (optional)](#code-signing-optional)
-12. [How delivery works](#how-delivery-works)
-13. [Operations](#operations)
-14. [Configuration reference](#configuration-reference)
-15. [CLI command reference](#cli-command-reference)
-16. [Troubleshooting](#troubleshooting)
+1. [Quickstart — try it locally](#quickstart--try-it-locally)
+2. [How it works](#how-it-works)
+3. [Core concepts](#core-concepts)
+4. [Repository layout](#repository-layout)
+5. [Requirements](#requirements)
+6. [Part 1 — Run the server (self-host)](#part-1--run-the-server-self-host)
+7. [Part 2 — Install the CLI and sign in](#part-2--install-the-cli-and-sign-in)
+8. [Part 3 — Create apps & deployments](#part-3--create-apps--deployments)
+9. [Part 4 — Connect your React Native app](#part-4--connect-your-react-native-app)
+10. [Part 5 — Publish your first release](#part-5--publish-your-first-release)
+11. [Managing releases](#managing-releases)
+12. [Code signing (optional)](#code-signing-optional)
+13. [How delivery works](#how-delivery-works)
+14. [Operations](#operations)
+15. [Configuration reference](#configuration-reference)
+16. [CLI command reference](#cli-command-reference)
+17. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -92,11 +120,14 @@ The default self-host stack runs four services on a single Docker host:
 | `shared/`          | `@codemagic/patch-shared` | Types and helpers shared across packages                            |
 | `deploy/selfhost/` | —                         | Caddyfile, MinIO bucket policy, dashboard image build               |
 | `scripts/selfhost/`| —                         | `install.sh`, `backup.sh`, `restore.sh`, `upgrade.sh`, `smoke.sh`   |
-| `examples/`        | —                         | Local-dev seed data and bundle fixtures                             |
+| `scripts/local-eval/` | —                      | Local evaluation stack bootstrap (`up.sh`) and its smoke checks     |
+| `examples/`        | —                         | Evaluation-stack seed data, bundle fixtures, and the [on-device demo app](examples/on-device-demo/README.md) |
 
 ---
 
 ## Requirements
+
+> Just evaluating? The [Quickstart](#quickstart--try-it-locally) needs none of this — only Docker.
 
 **Server host**
 

--- a/examples/on-device-demo/README.md
+++ b/examples/on-device-demo/README.md
@@ -1,0 +1,82 @@
+# On-device demo — watch an OTA update apply
+
+A minimal React Native app, preconfigured against the [local evaluation stack](../../README.md#quickstart--try-it-locally), whose whole purpose is to make an OTA update visible: it fills the screen with a version banner (**v1**, blue). You change one line, publish a release, relaunch — and the banner flips to **v2**, green. That flip is Codemagic Patch replacing the app's JS bundle, using the exact same client SDK, CLI, and server code paths as production.
+
+The app uses the SDK's manual flow (`checkForUpdate` → `downloadUpdate` → `installUpdate`) so you can see each phase on screen — checking, download progress, installed — instead of it all happening silently inside `sync()`.
+
+## Prerequisites
+
+- The local evaluation stack is **up**: run `../../scripts/local-eval/up.sh` from the repo root. It also installs the `cmpatch` CLI globally.
+- You are signed in once: `cmpatch login --server-url http://localhost:3000` (approves instantly)
+- Node.js ≥ 22.11 and Yarn (via Corepack).
+- **iOS**: macOS with Xcode and an iOS Simulator
+- **Android**: an Android SDK with a running emulator, and `adb` on PATH.
+
+## One-time setup
+
+From this directory:
+
+```bash
+yarn install
+yarn demo:setup:ios   # iOS only — installs pods (Bundler with the pinned lockfile, falling back to `pod` on PATH)
+```
+
+## Build and install the app (v1)
+
+```bash
+yarn demo:ios       # iOS Simulator
+yarn demo:android   # Android emulator
+```
+
+Both build the **Release** configuration with `--no-packager` — deliberate: the app must boot from its *embedded* bundle, because that is the bundle an OTA update replaces. A debug build served by Metro would bypass the update mechanism entirely.
+
+`demo:android` first runs `adb reverse tcp:3000 tcp:3000` and `adb reverse tcp:9100 tcp:9100`, so `localhost` inside the emulator reaches the stack's API and storage ports on your host.
+
+On launch the app shows the blue **v1** banner and, after a moment, *"Up to date — you are running v1."*
+
+## Publish an update and watch it apply
+
+1. Edit [`App.tsx`](App.tsx) — change the marked line:
+
+   ```ts
+   const APP_VERSION = 'v1';   // → 'v2'
+   ```
+
+2. Publish it as an OTA release, from this directory:
+
+   ```bash
+   # iOS
+   cmpatch release-react \
+     --server-url http://localhost:3000 \
+     --app demo-app --deployment staging-ios \
+     --platform ios
+
+   # Android
+   cmpatch release-react \
+     --server-url http://localhost:3000 \
+     --app demo-app --deployment staging-android \
+     --platform android
+   ```
+
+3. In the app, tap **Check again**. It finds the release, shows download progress, then offers **Update installed — Relaunch**. Tap it: the banner flips to the green **v2**.
+
+The update was staged with the default `ON_NEXT_RESTART` install mode, so a manual cold start (or the Relaunch button, which calls `restartApp()`) is what boots the new bundle.
+
+## How it's wired
+
+The SDK is configured by three native values, already baked into the app:
+
+| Key | iOS (`ios/PatchDemo/Info.plist`) | Android (`android/.../values/strings.xml`) |
+| --- | --- | --- |
+| `CodemagicPatchApiUrl` | `http://localhost:3000` | `http://localhost:3000` |
+| `CodemagicPatchDownloadBaseUrl` | `http://localhost:9100/codemagic-patch` | `http://localhost:9100/codemagic-patch` |
+| `CodemagicPatchDeploymentKey` | `dev_local_ios_deployment_key` | `dev_local_android_deployment_key` |
+
+The matching `staging-ios` / `staging-android` deployments (and the `demo-app` app) are created by the stack's seed. 
+
+## Troubleshooting
+
+- **"Local stack unreachable — is it running?"** — the evaluation stack isn't up (or was torn down). Run `../../scripts/local-eval/up.sh` and check again.
+- **Android stops finding updates after an emulator restart** — `adb reverse` mappings don't survive the emulator or adb server restarting. Re-run `yarn demo:android`, or just the two `adb reverse` commands from [`package.json`](package.json).
+- **`release-react` fails with a duplicate-release error** — you published the exact same bundle twice. Change `APP_VERSION` (or any code) and publish again.
+- **Start over** — `docker compose -f docker-compose.dev.yml down -v` from the repo root, then `./scripts/local-eval/up.sh`; the seed recreates the app, deployments, and token.


### PR DESCRIPTION
Improve the local evaluation experience by making it easier to discover and try Codemagic Patch before setting up a production self-hosted environment.