### PR TITLE
Add cli/README.md for the npm package page

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -33,8 +33,8 @@ cmpatch release-react --deployment Staging
 | Group | Description |
 | --- | --- |
 | `release` | Publish, inspect, patch, promote, and roll back OTA releases. |
-| `management` | Manage teams, apps, deployments, and deployment history. |
-| `iam` | Authenticate, manage tokens, and manage team members. |
+| `management` | Manage apps, deployments, and deployment history. |
+| `auth` | Authenticate, manage tokens, and manage team members. |
 | `diagnostics` | Diagnose local setup and OTA readiness (`cmpatch doctor`). |
 | `config` | Store defaults and inspect the effective local context. |
 | `fingerprint` | Compute fingerprints and inspect device update logs. |
@@ -46,13 +46,13 @@ Use `cmpatch help <group>` for the commands in a group, `cmpatch help <command>`
 Most commands accept `--format json|table`. When stdout is a terminal, output defaults to a human-readable table; when piped, it defaults to JSON, so the CLI is directly scriptable:
 
 ```sh
-cmpatch app list --format json | jq '.[].name'
+cmpatch app list --format json | jq '.apps[].name'
 ```
 
 ## Configuration
 
 - **User config:** `~/.codemagic-patch/config.json` — CLI-wide defaults such as `serverUrl` and `team`. Credentials are stored per server in `~/.codemagic-patch/credentials.json`. Set the `CODEMAGIC_PATCH_HOME` environment variable to relocate this directory.
-- **Project config:** `codemagic-patch.config.json` at your project root (or a `cmpatch` key in `package.json`) — per-project defaults such as `app`, `deployment`, and platform-specific overrides. Created by `cmpatch init`.
+- **Project config:** `codemagic-patch.config.json` at your project root (or a `codemagicPatch` key in `package.json`) — per-project defaults such as `app`, `deployment`, and platform-specific overrides. Created by `cmpatch init`.
 
 Explicit flags always take precedence over configured defaults. Run `cmpatch context` to inspect the effective configuration, and `cmpatch doctor` to diagnose setup issues.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,107 @@
+# @codemagic/patch-cli
+
+Command-line interface for releasing and managing over-the-air (OTA) React Native updates with [Codemagic Patch](https://github.com/codemagic-ci-cd/codemagic-patch). Provides the `cmpatch` command.
+
+## Requirements
+
+- Node.js >= 20
+
+## Install
+
+```sh
+npm install -g @codemagic/patch-cli
+```
+
+After installation, `cmpatch` is available on your `PATH`. To run one-off commands without installing globally:
+
+```sh
+npx -p @codemagic/patch-cli cmpatch <command>
+```
+
+Note that plain `npx cmpatch` does not resolve — npx looks up packages by package name, not by binary name.
+
+To remove the global installation:
+
+```sh
+npm uninstall -g @codemagic/patch-cli
+```
+
+### From source
+
+To build and install the CLI from a clone of this repository, run at the repository root:
+
+```sh
+yarn install
+yarn cli:install-global
+```
+
+This builds the CLI, packs it into a tarball, and installs it globally.
+
+### Development mode
+
+To run the CLI directly from source without installing:
+
+```sh
+yarn workspace @codemagic/patch-cli dev -- <args>
+# e.g.
+yarn workspace @codemagic/patch-cli dev -- --version
+```
+
+## Quick start
+
+```sh
+# 1. Authenticate against your Codemagic Patch server
+#    (opens the dashboard sign-in in your browser; add --no-browser to just
+#     print the URL, or --token <cm_pat_...> for headless machines)
+cmpatch login --server-url https://updates.example.com
+
+# 2. Set up project defaults (interactive wizard)
+cmpatch init
+
+# 3. Publish a React Native bundle as an OTA release
+cmpatch release-react --deployment Staging --dry-run   # preview first
+cmpatch release-react --deployment Staging
+```
+
+## Commands
+
+| Group | Description |
+| --- | --- |
+| `release` | Publish, inspect, patch, promote, and roll back OTA releases. |
+| `management` | Manage teams, apps, deployments, and deployment history. |
+| `iam` | Authenticate, manage tokens, and manage team members. |
+| `diagnostics` | Diagnose local setup and OTA readiness (`cmpatch doctor`). |
+| `config` | Store defaults and inspect the effective local context. |
+| `fingerprint` | Compute fingerprints and inspect device update logs. |
+
+Use `cmpatch help <group>` for the commands in a group, `cmpatch help <command>` for per-command usage and examples, and `cmpatch --version` to print the CLI version.
+
+## Output formats
+
+Most commands accept `--format json|table`. When stdout is a terminal, output defaults to a human-readable table; when piped, it defaults to JSON, so the CLI is directly scriptable:
+
+```sh
+cmpatch app list --format json | jq '.[].name'
+```
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Server or runtime error (not found, conflict, rate limited, …) |
+| 2 | Authentication required or usage error |
+| 3 | Validation error |
+| 4 | Account disabled |
+| 130 | Interactive prompt aborted (Ctrl-C) |
+
+## Configuration
+
+- **User config:** `~/.codemagic-patch/config.json` — CLI-wide defaults such as `serverUrl` and `team`. Credentials are stored per server in `~/.codemagic-patch/credentials.json`. Set the `CODEMAGIC_PATCH_HOME` environment variable to relocate this directory.
+- **Project config:** `codemagic-patch.config.json` at your project root (or a `cmpatch` key in `package.json`) — per-project defaults such as `app`, `deployment`, and platform-specific overrides. Created by `cmpatch init`.
+
+Explicit flags always take precedence over configured defaults. Run `cmpatch context` to inspect the effective configuration, and `cmpatch doctor` to diagnose setup issues.
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,41 +12,6 @@ Command-line interface for releasing and managing over-the-air (OTA) React Nativ
 npm install -g @codemagic/patch-cli
 ```
 
-After installation, `cmpatch` is available on your `PATH`. To run one-off commands without installing globally:
-
-```sh
-npx -p @codemagic/patch-cli cmpatch <command>
-```
-
-Note that plain `npx cmpatch` does not resolve — npx looks up packages by package name, not by binary name.
-
-To remove the global installation:
-
-```sh
-npm uninstall -g @codemagic/patch-cli
-```
-
-### From source
-
-To build and install the CLI from a clone of this repository, run at the repository root:
-
-```sh
-yarn install
-yarn cli:install-global
-```
-
-This builds the CLI, packs it into a tarball, and installs it globally.
-
-### Development mode
-
-To run the CLI directly from source without installing:
-
-```sh
-yarn workspace @codemagic/patch-cli dev -- <args>
-# e.g.
-yarn workspace @codemagic/patch-cli dev -- --version
-```
-
 ## Quick start
 
 ```sh
@@ -55,7 +20,7 @@ yarn workspace @codemagic/patch-cli dev -- --version
 #     print the URL, or --token <cm_pat_...> for headless machines)
 cmpatch login --server-url https://updates.example.com
 
-# 2. Set up project defaults (interactive wizard)
+# 2. Set up project defaults
 cmpatch init
 
 # 3. Publish a React Native bundle as an OTA release
@@ -83,17 +48,6 @@ Most commands accept `--format json|table`. When stdout is a terminal, output de
 ```sh
 cmpatch app list --format json | jq '.[].name'
 ```
-
-## Exit codes
-
-| Code | Meaning |
-| --- | --- |
-| 0 | Success |
-| 1 | Server or runtime error (not found, conflict, rate limited, …) |
-| 2 | Authentication required or usage error |
-| 3 | Validation error |
-| 4 | Account disabled |
-| 130 | Interactive prompt aborted (Ctrl-C) |
 
 ## Configuration
 


### PR DESCRIPTION
Adds `cli/README.md` ahead of the first npm publish of `@codemagic/patch-cli`

- Becomes the npm package page (npm includes `README.md` in the tarball automatically; verified with `npm pack --dry-run` — 5 files).
- Fixes the currently broken `homepage` link in `cli/package.json` (`cli#readme`).
- Install section covers global npm install, `npx -p @codemagic/patch-cli cmpatch` (with a note that plain `npx cmpatch` does not resolve), from-source install, and development mode.
