### PR TITLE
Add CodePush migration guide and document RN 0.73 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ docker compose -f docker-compose.dev.yml down -v
 16. [CLI command reference](#cli-command-reference)
 17. [Repository layout](#repository-layout)
 
+**Guides**
+
+18. [Migrating from CodePush](docs/migrate-from-codepush.md)
+
 ---
 
 ## How it works
@@ -141,7 +145,8 @@ The default self-host stack runs four services on a single Docker host:
 
 **React Native app**
 
-- React Native `>=0.76`, React `>=18`
+- React Native `>=0.73`, React `>=18` — New Architecture support starts at RN 0.76; RN 0.73–0.75 are supported on the Old (Paper) Architecture only
+- Android `minSdkVersion` 23+
 
 ---
 
@@ -337,6 +342,8 @@ cmpatch deployment list --app MyApp-Android --format table
 
 ## Part 4 — Connect your React Native app
 
+> **Migrating from CodePush?** The [migration guide](docs/migrate-from-codepush.md) maps `react-native-code-push` native config, JS APIs, and `code-push` CLI commands to their Codemagic Patch equivalents.
+
 Add the SDK:
 
 ```bash
@@ -378,6 +385,8 @@ Wire the config and native bundle selection manually.
   // ...
   CodemagicPatch.bundleURL() ?? Bundle.main.url(forResource: "main", withExtension: "jsbundle")
   ```
+  On RN ≤ 0.76, where the app template still ships an Objective-C++ `AppDelegate.mm`, override `sourceURLForBridge:` with the same selection — see [`client/README.md` §Configuration](client/README.md#configuration) for the forward-declaration snippet.
+
   Reference: `client/plugin/src/withIosBundleURL.ts`
 
 **Android**
@@ -939,6 +948,7 @@ List/metrics commands accept `--format table|json`.
 | `scripts/selfhost/`| —                         | `install.sh`, `backup.sh`, `restore.sh`, `upgrade.sh`, `smoke.sh`   |
 | `scripts/local-eval/` | —                      | Local evaluation stack bootstrap (`up.sh`) and its smoke checks     |
 | `examples/`        | —                         | Evaluation-stack seed data, bundle fixtures, and the [on-device demo app](examples/on-device-demo/README.md) |
+| `docs/`            | —                         | Guides — e.g. [migrating from CodePush](docs/migrate-from-codepush.md)  |
 
 
 ## Feedback

--- a/client/README.md
+++ b/client/README.md
@@ -24,7 +24,8 @@ From this SDK:
 
 ## Requirements
 
-- React Native `0.76+` — Old Architecture and New Architecture
+- React Native `0.73+` — New Architecture support starts at RN 0.76; RN 0.73–0.75 are supported on the Old (Paper) Architecture only
+- Android `minSdkVersion` 23+ (the library follows the host's `rootProject.ext.minSdkVersion`; without one it builds at 23)
 - Android native build with CMake/JNI support
 - iOS native build with CocoaPods and mixed Swift/ObjC++ compilation
 - Expo SDK 52+ (via the bundled config plugin — see [Expo apps](#expo-apps))
@@ -38,7 +39,7 @@ npm install @codemagic/react-native-patch
 yarn add @codemagic/react-native-patch
 ```
 
-`react` (`>=18`) and `react-native` (`>=0.76`) are peer dependencies. On iOS, install the native pod:
+`react` (`>=18`) and `react-native` (`>=0.73`) are peer dependencies. On iOS, install the native pod:
 
 ```sh
 cd ios && pod install
@@ -139,6 +140,25 @@ The two URLs point at different systems (API server vs. object storage / CDN), w
    }
    ```
 
+   On RN ≤ 0.76, where the app template still ships an Objective-C++ `AppDelegate.mm`, override `sourceURLForBridge:` with the same selection. The native module is a Swift pod exposed to Objective-C as `@objc(CodemagicPatch)`; its generated `-Swift.h` is not on the host target's header search paths and `@import` is unavailable in ObjC++, so forward-declare the surface you call:
+
+   ```objc
+   // CodemagicPatch is a Swift pod exposed as @objc(CodemagicPatch); forward-declare it —
+   // the implementation links in from the pod's static library.
+   @interface CodemagicPatch : NSObject
+   + (NSURL *_Nullable)bundleURL;
+   @end
+
+   - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+   {
+     NSURL *otaBundle = [CodemagicPatch bundleURL];
+     if (otaBundle != nil) {
+       return otaBundle;
+     }
+     return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+   }
+   ```
+
    Expected embedded bundle names are `index.android.bundle` (Android) and `main.jsbundle` (iOS). If the SDK cannot determine a non-blank binary version (`versionName` / `CFBundleShortVersionString`), it no-ops and falls back to the embedded bundle.
 
 3. **Register the native module** for your architecture — the TurboModule (New Architecture) or the bridge module/package (Old Architecture). Autolinking handles this in most apps.
@@ -188,6 +208,8 @@ import {
 ## Documentation
 
 Full integration guide, update protocol, and self-hosting instructions live in the [Codemagic Patch repository](https://github.com/codemagic-ci-cd/codemagic-patch).
+
+Coming from `react-native-code-push`? The [CodePush migration guide](https://github.com/codemagic-ci-cd/codemagic-patch/blob/main/docs/migrate-from-codepush.md) maps the native config resources, JS APIs, and CLI commands to their Codemagic Patch equivalents.
 
 ## License
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemagic/react-native-patch",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "React Native client SDK for Codemagic Patch — over-the-air JavaScript & asset updates for React Native and Expo apps.",
   "keywords": [
     "react-native",

--- a/docs/migrate-from-codepush.md
+++ b/docs/migrate-from-codepush.md
@@ -1,0 +1,272 @@
+# Migrating from CodePush
+
+This guide is for teams running `react-native-code-push` — against App Center
+CodePush, a standalone `code-push-server`, or one of its forks — who are moving
+to Codemagic Patch. It covers the two things that change on your side:
+
+1. [Client SDK migration](#1-client-sdk-migration) — swapping
+   `react-native-code-push` for `@codemagic/react-native-patch`
+2. [CLI usage differences](#2-cli-usage-differences) — moving from the
+   `code-push` CLI (or `appcenter codepush`) to `cmpatch`
+
+Server setup is a prerequisite, not part of this guide. See
+[Part 1 — Run the server (self-host)](../README.md#part-1--run-the-server-self-host)
+in the root README for a production self-host, or the
+[local quickstart](../README.md#quickstart--try-it-locally) to evaluate on a
+laptop first.
+
+## The mental model carries over
+
+Apps, deployments, deployment keys, `Staging`/`Production`, `release-react`,
+target binary versions, mandatory releases, rollout percentages, promote, and
+rollback all exist in Codemagic Patch and mean what you expect. The structural
+differences worth knowing before you start:
+
+- **Two base URLs instead of one server URL.** Devices talk to the API server
+  for manifest routing and download artifacts from static storage / a CDN.
+  Your app configures both (`CodemagicPatchApiUrl` +
+  `CodemagicPatchDownloadBaseUrl`)
+- **All client configuration is native-resource-only.** There is no JS-side
+  deployment key, server URL, or config API.
+- **No OTA path across the migration.** Devices running the CodePush SDK can
+  never receive a Codemagic Patch release — the swap ships as a regular
+  store/binary release (see [§1.6](#16-ship-the-migration-as-a-binary-release)).
+- **No server-side data import.** Apps, deployments, release history, and
+  metrics are not migrated from a CodePush server. You recreate apps and
+  deployments with the CLI and start a fresh release history.
+
+## Prerequisites
+
+- A running Codemagic Patch server you can reach.
+- The `cmpatch` CLI installed and authenticated
+  ([`cli/README.md`](../cli/README.md)):
+
+  ```sh
+  cmpatch login --server-url https://updates.example.com
+  cmpatch app create --name my-app        # creates Staging + Production
+  cmpatch deployment list --app my-app    # note the new deployment keys
+  ```
+
+Deployment key **values** are new — CodePush keys cannot be reused. Everywhere
+this guide says "deployment key", use the value printed by
+`cmpatch deployment list`.
+
+## 1. Client SDK migration
+
+### 1.1 Swap the package
+
+```sh
+yarn remove react-native-code-push
+yarn add @codemagic/react-native-patch
+cd ios && pod install
+```
+
+Also remove CodePush-specific build wiring that has no Patch equivalent:
+
+- Android: delete the
+  `apply from: "../../node_modules/react-native-code-push/android/codepush.gradle"`
+  line from `android/app/build.gradle`.
+- Any multi-deployment build-config machinery that swapped
+  `CodePushDeploymentKey` per build type keeps working conceptually — it just
+  writes the new resource names below instead.
+
+### 1.2 Replace native configuration resources
+
+| CodePush (strings.xml / Info.plist) | Codemagic Patch | Notes |
+| --- | --- | --- |
+| `CodePushDeploymentKey` | `CodemagicPatchDeploymentKey` | New value, from `cmpatch deployment list` |
+| Android: `CodePushServerUrl`<br>iOS: `CodePushServerURL` | `CodemagicPatchApiUrl` **and** `CodemagicPatchDownloadBaseUrl` | One URL becomes two: API origin + artifact origin |
+| `CodePushPublicKey` | `CodemagicPatchPublicKey` | Optional; only for client-side signature enforcement |
+
+The full resource contract (which URL carries a path prefix, what the SDK
+appends) is in [`client/README.md` §Configuration](../client/README.md#configuration)
+— follow it as written; this table is only the rename map.
+
+### 1.3 Replace the native bundle wiring
+
+The wiring shape is the same as CodePush — swap the class:
+
+- **Android** (`MainApplication`): `CodePush.getJSBundleFile()` →
+  `CodemagicPatch.getJSBundleFile(applicationContext)`. Remove the existing
+  `com.microsoft.codepush.react.CodePush` import and add
+  `import io.codemagic.patch.CodemagicPatch` (with a trailing semicolon in
+  Java).
+- **iOS** (`AppDelegate`): `[CodePush bundleURL]` / `CodePush.bundleURL()` →
+  `[CodemagicPatch bundleURL]` / `CodemagicPatch.bundleURL()`. In Swift,
+  remove `import CodePush` and add `import CodemagicPatchClient`.
+
+Use the per-RN-version snippets in
+[`client/README.md` §Configuration](../client/README.md#configuration) — they
+cover the RN 0.82+ `reactHost` form on Android and the Objective-C++
+forward-declaration needed on RN ≤ 0.76 iOS templates. Expo apps skip this
+section entirely and use the bundled config plugin instead
+([`client/README.md` §Expo apps](../client/README.md#expo-apps)) — something
+CodePush never offered first-party.
+
+### 1.4 Migrate the JS integration
+
+There is no `codePush()` higher-order component and no decorator. Delete the
+HOC wrapper and call `sync()` from your own lifecycle code (e.g. on mount, or
+from an `AppState` listener if you want resume-triggered checks).
+
+API mapping:
+
+| `react-native-code-push` | `@codemagic/react-native-patch` | Notes |
+| --- | --- | --- |
+| `codePush(options)(App)` HOC | — | Call `sync()` explicitly |
+| `codePush.sync(options, statusCb, progressCb, mismatchCb)` | `sync(options?, onProgress?)` | Returns a final `SyncStatus` promise; no per-transition status callback |
+| `codePush.checkForUpdate(key?, mismatchCb?)` | `checkForUpdate()` | No JS deployment-key override. Binary mismatch callback is replaced by `isStoreUpdateAvailable` / `latestBinaryVersion` on the result |
+| `remotePackage.download(progressCb)` | `downloadUpdate(remotePackage, onProgress?)` | Module function, not a method on the package object |
+| `localPackage.install(installMode, minBackgroundDuration)` | `installUpdate(localPackage, { installMode, minimumBackgroundDuration })` | |
+| `codePush.notifyAppReady()` / `notifyApplicationReady()` | `notifyAppReady()` | `sync()` still calls it internally |
+| `codePush.restartApp(onlyIfUpdateIsPending?)` | `restartApp(onlyIfUpdateIsPending?)` | |
+| `codePush.allowRestart()` / `disallowRestart()` | `allowRestart()` / `disallowRestart()` | |
+| `codePush.getUpdateMetadata(updateState?)` | — | Not exposed; `checkForUpdate()` / `sync()` results carry package metadata |
+| `codePush.clearUpdates()` | — | The server-driven `embedded-revert` action covers "return the fleet to the binary bundle" |
+| JS-side key/server config (`setDeploymentKey`, sync `deploymentKey` option) | — | Configuration is native-resource-only ([§1.2](#12-replace-native-configuration-resources)) |
+
+Option and enum mapping:
+
+- **`InstallMode`** — numeric enum → string literals: `"IMMEDIATE"`,
+  `"ON_NEXT_RESTART"`, `"ON_NEXT_RESUME"`, `"ON_NEXT_SUSPEND"`. Defaults are
+  unchanged from CodePush: `installMode` defaults to `ON_NEXT_RESTART`,
+  `mandatoryInstallMode` to `IMMEDIATE`.
+- **`minimumBackgroundDuration` is now in milliseconds** (CodePush used
+  seconds). A carried-over `minimumBackgroundDuration: 300` now means 300 ms —
+  multiply by 1000.
+- **`SyncStatus`** — numeric enum → strings. `sync()` resolves to
+  `"up-to-date"`, `"update-installed"`, `"embedded-revert-applied"`,
+  `"sync-in-progress"`, or `"error"`.
+- **`updateDialog` is gone.** The SDK never shows UI. Build your own prompt
+  from `checkForUpdate()` metadata (`releaseNotes`, `isMandatory`) and drive
+  the manual flow.
+- **`checkFrequency` is gone.** Sync timing is yours: call `sync()` when you
+  want `ON_APP_START` / `ON_APP_RESUME` behavior.
+- **New result kind: `embedded-revert`.** `checkForUpdate()` can return
+  `{ action: "embedded-revert" }`, meaning the server wants the device back on
+  the embedded bundle. `sync()` handles it automatically; a manual flow passes
+  the result straight to `installUpdate()`.
+
+The full API surface and option types live in
+[`client/src/types.ts`](../client/src/types.ts).
+
+### 1.5 Support floor
+
+Codemagic Patch supports React Native 0.73+ (RN 0.73–0.75 on the Old
+Architecture only; New Architecture support starts at RN 0.76) and Expo
+SDK 52+ — see [`client/README.md` §Requirements](../client/README.md#requirements).
+Apps on older RN versions must upgrade RN before (or with) the migration
+binary.
+
+### 1.6 Ship the migration as a binary release
+
+The SDK swap itself cannot be delivered over the air. Plan the cutover as:
+
+1. Ship a store/binary release containing `@codemagic/react-native-patch`,
+   configured against your Patch server.
+2. Keep the old CodePush server running (read-only is fine) until enough of
+   the fleet has rotated onto the new binary — devices on old binaries still
+   check the CodePush endpoint.
+3. Publish subsequent OTA updates with `cmpatch release-react` targeting the
+   new binary versions only.
+
+Verify the integration end to end before shipping — the fastest loop is the
+[on-device demo](../examples/on-device-demo/README.md), which runs the full
+publish → sync → rollback cycle against the local evaluation stack.
+
+## 2. CLI usage differences
+
+Install: `cmpatch` ships as `@codemagic/patch-cli`
+([`cli/README.md`](../cli/README.md)). Legacy commands below are the
+standalone `code-push` CLI's; `appcenter codepush` subcommands map the same
+way.
+
+### 2.1 Authentication and identity
+
+| Legacy | `cmpatch` | Notes |
+| --- | --- | --- |
+| `code-push register` | — | Accounts come from the server's sign-in (GitHub OAuth) or `cmpatch member invite` / `member provision` |
+| `code-push login <serverUrl> --accessKey <key>` | `cmpatch login --server-url <url>` | Opens browser sign-in (loopback redirect); `--token cm_pat_...` for headless machines |
+| `code-push logout` | `cmpatch logout` | |
+| `code-push whoami` | `cmpatch whoami` | |
+| `code-push access-key add/ls/rm` | `cmpatch token create/list/revoke` | Token value shown once at creation |
+| `code-push session ls/rm` | — | |
+
+Credentials are stored per server under `~/.codemagic-patch/`; the server URL
+is remembered after login instead of being passed per command.
+
+### 2.2 App and deployment management
+
+| Legacy | `cmpatch` | Notes |
+| --- | --- | --- |
+| `code-push app add/ls/rename/rm` | `cmpatch app create/list/rename/remove` | `app create` seeds `Staging` + `Production`, same as CodePush. Also new: `app show`, `app setting` (e.g. `--require-code-signing`) |
+| `code-push app transfer` | — | OSS self-host runs a single team; use `member` roles instead |
+| `code-push collaborator add/ls/rm` | `cmpatch member add/invite/list/update/remove` | Team-scoped roles (`viewer`/`developer`/`admin`/`owner`) instead of per-app collaborators |
+| `code-push deployment add/ls/rename/rm/clear` | `cmpatch deployment create/list/rename/remove/clear` | `deployment list` prints deployment keys and a metrics summary |
+| `code-push deployment history` | `cmpatch deployment history` | Alias for `release list --include metrics --limit 50` |
+
+### 2.3 Releasing
+
+| Legacy | `cmpatch` | Notes |
+| --- | --- | --- |
+| `code-push release-react <app> <platform>` | `cmpatch release-react --app <app> --platform <ios\|android>` | Positionals become flags; see the flag map below |
+| `code-push release <app> <contents> <targetBinaryVersion>` | `cmpatch release create` | Pre-built bundle directory; explicit `--target-binary-version` and `--platform` required |
+| `code-push release-expo` | — | `release-react` auto-detects Expo (`--bundler auto\|metro\|expo`) |
+| `code-push release-native` | — | Binary releases are not registered through the CLI |
+| `code-push patch` | `cmpatch release patch` | Rollout, mandatory, description, target binary version |
+| `code-push promote` | `cmpatch release promote` | |
+| `code-push rollback` | `cmpatch release rollback` | |
+| `code-push debug <platform>` | `cmpatch debug` | Streams device logs via `adb` / `xcrun` |
+| — | `cmpatch release list/show/inspect`, `release disable/enable` | New: inspect worker status (`--wait`), pull a release from/back into static delivery |
+| — | `cmpatch deployment metrics`, `cmpatch release metrics` | Replaces reading metrics off `deployment ls` |
+| — | `cmpatch init`, `cmpatch context`, `cmpatch doctor`, `cmpatch fingerprint` | Project defaults wizard, effective-config dump, setup diagnosis, fingerprint tooling |
+
+### 2.4 `release-react` flag map
+
+| Legacy | `cmpatch release-react` | Notes |
+| --- | --- | --- |
+| `<appName>` positional | `--app` | Or a project default from `cmpatch init` |
+| `<platform>` positional | `--platform` | Required |
+| `--deploymentName` / `-d` | `--deployment` | |
+| `--targetBinaryVersion` / `-t` | `--target-binary-version` | Auto-detection from `Info.plist` / `build.gradle` is preserved when omitted |
+| `--description` | `--release-notes` | |
+| `--mandatory` / `-m` | `--mandatory` | |
+| `--rollout` / `-r` | `--rollout-percentage` | |
+| `--disabled` / `-x` | `--disabled` | |
+| `--entryFile` | `--entry-file` | |
+| `--gradleFile` | `--gradle-file` | |
+| `--plistFile` | `--plist-file` | |
+| `--plistFilePrefix` | `--plist-file-prefix` | |
+| `--sourcemapOutput` | `--sourcemap-output` | |
+| `--privateKeyPath` | `--private-key-path` | Code signing parity |
+| `--noDuplicateReleaseError` | `--no-duplicate-release-error` | Byte-identical duplicates are rejected by default, as before |
+| `--useHermes` | `--hermes auto\|true\|false` | `auto` reads the project config |
+| `--extraHermesFlags` | `--extra-hermes-flag` | Repeatable |
+| `--extraBundlerOption` | `--bundler-args` | Repeatable; use `--bundler-args=--reset-cache` for values starting with a dash |
+| `--development`, `--bundleName`, `--outputDir`, `--podFile`, `--xcodeProjectFile`, `--xcodeTargetName`, `--buildConfigurationName`, `--buildNumber` | — | Dropped: releases are production bundles with platform-standard names, and iOS version detection reads `Info.plist` directly |
+| — | `--bundler`, `--dry-run`, `--yes`, `--non-interactive`, `--format json\|table` | New |
+
+### 2.5 Behavioral differences to expect
+
+- **Fingerprints are mandatory.** The server rejects a release upload that
+  carries no fingerprint, and there is no CLI flag to skip it.
+  `release-react` always computes the native-project fingerprint (via
+  `@expo/fingerprint`) and fails with a validation error when it can't — run
+  from the project root or pass `--project-root`. `release` computes it the
+  same way, or accepts a precomputed value via `--fingerprint`. The
+  fingerprint drives compatibility-based delivery across binary versions, a
+  concept CodePush did not have.
+- **Interactive confirmation.** In a terminal, release-producing commands
+  print their mutation context and require user confirmation; CI passes
+  `--yes`.
+- **Project defaults.** `cmpatch init` writes
+  `codemagic-patch.config.json` (app, deployment, platform overrides), so CI
+  invocations need fewer flags; explicit flags always win. `cmpatch context`
+  shows the effective result.
+- **Scriptable output.** Most commands accept `--format json|table`; piped
+  output defaults to JSON, so the CLI is directly scriptable
+  ([`cli/README.md` §Output formats](../cli/README.md#output-formats)).
+
+The complete command list lives in the root README's
+[CLI command reference](../README.md#cli-command-reference); run
+`cmpatch help` or `cmpatch <command> --help` for full flag semantics.


### PR DESCRIPTION
## Summary
- Add `docs/migrate-from-codepush.md` — the CodePush → Codemagic Patch migration guide (client SDK swap, native config rename map, JS API mapping, `code-push` → `cmpatch` CLI mapping), ported from the internal monorepo with internal-only references remapped to this repo's public docs (root README sections, `cli/README.md`, `client/README.md`, `client/src/types.ts`)
- Root `README.md`: lower the documented RN requirement to `>=0.73` (RN 0.73–0.75 Old/Paper Architecture only, New Architecture from 0.76), add Android `minSdkVersion 23+`, add an RN ≤ 0.76 Objective-C++ AppDelegate note in Part 4, and link the migration guide from the TOC, Part 4, and the repository layout table
- `client/README.md`: update Requirements to RN `0.73+` with the architecture caveat and minSdk 23, fix the peer-dependency note to `>=0.73` (matching the already-exported `package.json`), add the RN ≤ 0.76 `sourceURLForBridge:` forward-declaration snippet, and link the migration guide from the Documentation section
- Bump `@codemagic/react-native-patch` to `0.1.3`

## Test plan
- [x] All relative links in `docs/migrate-from-codepush.md` resolve to existing files
- [x] Cross-reference anchors (`#configuration`, `#expo-apps`, `#requirements`, `#part-1--run-the-server-self-host`, `#cli-command-reference`, `#output-formats`) match existing headings
- [x] No stale `>=0.76` / `0.76+` references remain in the touched docs
- [x] Review rendered markdown on GitHub (tables, TOC links, code blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)